### PR TITLE
Improved Schema validation.

### DIFF
--- a/thingif/src/androidTest/java/com/kii/thingif/features/SchemaMismatchTest.java
+++ b/thingif/src/androidTest/java/com/kii/thingif/features/SchemaMismatchTest.java
@@ -1,0 +1,191 @@
+package com.kii.thingif.features;
+
+import android.support.test.runner.AndroidJUnit4;
+import android.util.Pair;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import com.kii.thingif.ThingIFAPI;
+import com.kii.thingif.ThingIFAPITestBase;
+import com.kii.thingif.command.Action;
+import com.kii.thingif.command.Command;
+import com.kii.thingif.schema.Schema;
+import com.kii.thingif.testschemas.SetBrightness;
+import com.kii.thingif.testschemas.TurnPower;
+import com.kii.thingif.trigger.Trigger;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+@RunWith(AndroidJUnit4.class)
+public class SchemaMismatchTest extends ThingIFAPITestBase {
+
+    @Test
+    public void testCommandSchemaMismatch() throws Exception {
+
+        // Onboard.
+        ThingIFAPI api = this.craeteThingIFAPIWithDemoSchema("dummyAppId", "dummyAppKey");
+        this.addMockResponseForOnBoard(200, "dummyThingID", "dummyToken");
+
+        api.onboard("dummyThingID", "dummyPassword");
+
+        long currentTime = System.currentTimeMillis();
+        Schema s = this.createDefaultSchema();
+
+        // Creates Response of list commands.
+
+        // Schema mismatch command.
+        JsonObject command1 = new JsonObject();
+
+        command1.add("schema", new JsonPrimitive("non-match"));
+        command1.add("schemaVersion", new JsonPrimitive(100));
+        command1.add("target", new JsonPrimitive("thing:dummy-target-id"));
+        command1.add("commandState", new JsonPrimitive("SENDING"));
+        command1.add("issuer", new JsonPrimitive("user:dummy-user-id"));
+        command1.add("commandID", new JsonPrimitive("dummy-command-id1"));
+        command1.add("createdAt", new JsonPrimitive(currentTime));
+        command1.add("modifiedAt", new JsonPrimitive(currentTime));
+
+        // Actions.
+        JsonArray actions = new JsonArray();
+        JsonParser p  = new JsonParser();
+        JsonElement action1 = p.parse("{\"setBrightness\" : {\"brightness\":50} }");
+        actions.add(action1);
+
+        command1.add("actions", actions);
+
+        // Schema match command.
+        JsonObject command2 = new JsonObject();
+
+        command2.add("schema", new JsonPrimitive(s.getSchemaName()));
+        command2.add("schemaVersion", new JsonPrimitive(s.getSchemaVersion()));
+        command2.add("target", new JsonPrimitive("thing:dummy-target-id"));
+        command2.add("commandState", new JsonPrimitive("SENDING"));
+        command2.add("issuer", new JsonPrimitive("user:dummy-user-id"));
+        command2.add("commandID", new JsonPrimitive("dummy-command-id1"));
+        command2.add("createdAt", new JsonPrimitive(currentTime));
+        command2.add("modifiedAt", new JsonPrimitive(currentTime));
+
+        // Actions.
+        JsonArray actions2 = new JsonArray();
+        JsonElement action2 = p.parse("{\"setBrightness\" : {\"brightness\":100} }");
+        actions2.add(action2);
+        command2.add("actions", actions2);
+
+        // Create mock response.
+        JsonObject mockResponse = new JsonObject();
+        JsonArray commands = new JsonArray();
+        commands.add(command1);
+        commands.add(command2);
+        mockResponse.add("commands", commands);
+
+        this.addMockResponse(200, mockResponse);
+
+        // Inspect Result.
+        Pair<List<Command>, String> result = api.listCommands(0, null);
+        List<Command> list = result.first;
+        Assert.assertEquals(1, list.size());
+        Command receivedCommand = list.get(0);
+
+        List<Action> receivedActions = receivedCommand.getActions();
+        Assert.assertEquals(1, receivedActions.size());
+        Action receivedAction = receivedActions.get(0);
+        Assert.assertEquals("setBrightness", receivedAction.getActionName());
+        Assert.assertEquals(100, ((SetBrightness)receivedAction).brightness);
+    }
+
+    @Test
+    public void testTriggerSchemaMismatch() throws Exception {
+        // Onboard.
+        ThingIFAPI api = this.craeteThingIFAPIWithDemoSchema("dummyAppId", "dummyAppKey");
+        this.addMockResponseForOnBoard(200, "dummyThingID", "dummyToken");
+
+        api.onboard("dummyThingID", "dummyPassword");
+
+        long currentTime = System.currentTimeMillis();
+        Schema s = this.createDefaultSchema();
+
+        // Creates Response of list triggers.
+        String listResponse =
+                "{" +
+                "  \"triggers\": [" +
+                "    {" +
+                "      \"triggerID\": \"32b86360-d3be-11e5-9872-22000aa79e15\"," +
+                "      \"predicate\": {" +
+                "        \"triggersWhen\": \"CONDITION_TRUE\"," +
+                "        \"condition\": {" +
+                "          \"type\": \"eq\"," +
+                "          \"field\": \"power\"," +
+                "          \"value\": true" +
+                "        }," +
+                "        \"eventSource\": \"STATES\"" +
+                "      }," +
+                "      \"triggersWhat\": \"COMMAND\"," +
+                "      \"command\": {" +
+                "        \"schema\": \"InvalidSchema\"," +
+                "        \"schemaVersion\": 1," +
+                "        \"target\": \"thing:th.51e97aa00022-e4f8-5e11-771d-0bd87409\"," +
+                "        \"issuer\": \"user:33e070341321-5658-5e11-fd86-0637e2e2\"," +
+                "        \"actions\": [" +
+                "          {" +
+                "            \"turnPower\": {" +
+                "              \"power\": true" +
+                "            }" +
+                "          }" +
+                "        ]" +
+                "      }," +
+                "      \"disabled\": false" +
+                "    }," +
+                "    {" +
+                "      \"triggerID\": \"ab7c5100-d178-11e5-8070-22000a7f900d\"," +
+                "      \"predicate\": {" +
+                "        \"triggersWhen\": \"CONDITION_TRUE\"," +
+                "        \"condition\": {" +
+                "          \"type\": \"eq\"," +
+                "          \"field\": \"power\"," +
+                "          \"value\": true" +
+                "        }," +
+                "        \"eventSource\": \"STATES\"" +
+                "      }," +
+                "      \"triggersWhat\": \"COMMAND\"," +
+                "      \"command\": {" +
+                "        \"schema\": \"" + s.getSchemaName() + "\"," +
+                "        \"schemaVersion\":" + s.getSchemaVersion() + "," +
+                "        \"target\": \"thing:th.51e97aa00022-e4f8-5e11-771d-0bd87409\"," +
+                "        \"issuer\": \"user:33e070341321-5658-5e11-fd86-0637e2e2\"," +
+                "        \"actions\": [" +
+                "          {" +
+                "            \"turnPower\": {" +
+                "              \"power\": false" +
+                "            }" +
+                "          }" +
+                "        ]" +
+                "      }," +
+                "      \"disabled\": false" +
+                "    }" +
+                "  ]" +
+                "}";
+        JsonParser parser = new JsonParser();
+        this.addMockResponse(200, parser.parse(listResponse));
+
+        // Inspect result.
+        Pair<List<Trigger>, String> result = api.listTriggers(0, null);
+        List<Trigger> list = result.first;
+        Assert.assertEquals(1, list.size());
+        Trigger receivedTrigger = list.get(0);
+        Command command = receivedTrigger.getCommand();
+        Assert.assertEquals(s.getSchemaName(), command.getSchemaName());
+        Assert.assertEquals(s.getSchemaVersion(), command.getSchemaVersion());
+        Assert.assertEquals(1, command.getActions().size());
+        Action action = command.getActions().get(0);
+        Assert.assertEquals("turnPower", action.getActionName());
+        Assert.assertEquals(false, ((TurnPower)action).power);
+    }
+}

--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -484,7 +484,9 @@ public class ThingIFAPI implements Parcelable {
         return this.deserialize(schema, responseBody, Command.class);
     }
     /**
-     * List Commands in the specified Target.
+     * List Commands in the specified Target.<br>
+     * If the Schema of the Command included in the response does not matches with the Schema
+     * registered this ThingIfAPI instance, It won't be included in returned value.
      * @param bestEffortLimit Maximum number of the Commands in the response.
      *                        if the value is <= 0, default limit internally
      *                        defined is applied.
@@ -500,7 +502,6 @@ public class ThingIFAPI implements Parcelable {
      * paginationKey if there is next page to be obtained.
      * @throws ThingIFException Thrown when failed to connect IoT Cloud Server.
      * @throws ThingIFRestException Thrown when server returns error response.
-     * @throws UnsupportedSchemaException Thrown when the returned response has a schema that cannot handle this instance.
      * @throws UnsupportedActionException Thrown when the returned response has a action that cannot handle this instance.
      */
     public Pair<List<Command>, String> listCommands (
@@ -533,7 +534,7 @@ public class ThingIFAPI implements Parcelable {
                 int schemaVersion = commandJson.optInt("schemaVersion");
                 Schema schema = this.getSchema(schemaName, schemaVersion);
                 if (schema == null) {
-                    throw new UnsupportedSchemaException(schemaName, schemaVersion);
+                    continue;
                 }
                 commands.add(this.deserialize(schema, commandJson, Command.class));
             }
@@ -880,7 +881,9 @@ public class ThingIFAPI implements Parcelable {
     }
 
     /**
-     * List Triggers belongs to the specified Target.
+     * List Triggers belongs to the specified Target.<br>
+     * If the Schema of the Trigger included in the response does not matches with the Schema
+     * registered this ThingIfAPI instance, It won't be included in returned value.
      * @param bestEffortLimit limit the maximum number of the Triggers in the
      *                        Response. It ensures numbers in
      *                        response is equals to or less than specified number.
@@ -895,7 +898,6 @@ public class ThingIFAPI implements Parcelable {
      * in the target.
      * @throws ThingIFException Thrown when failed to connect IoT Cloud Server.
      * @throws ThingIFRestException Thrown when server returns error response.
-     * @throws UnsupportedSchemaException Thrown when the returned response has a schema that cannot handle this instance.
      * @throws UnsupportedActionException Thrown when the returned response has a action that cannot handle this instance.
      */
     @NonNull
@@ -933,7 +935,7 @@ public class ThingIFAPI implements Parcelable {
                     int schemaVersion = commandJson.optInt("schemaVersion");
                     schema = this.getSchema(schemaName, schemaVersion);
                     if (schema == null) {
-                        throw new UnsupportedSchemaException(schemaName, schemaVersion);
+                        continue;
                     }
                 }
                 triggers.add(this.deserialize(schema, triggerJson, Trigger.class));

--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -1036,30 +1036,7 @@ public class ThingIFAPI implements Parcelable {
     private Schema getSchema(String schemaName, int schemaVersion) {
         return this.schemas.get(new Pair<String, Integer>(schemaName, schemaVersion));
     }
-    private Action generateAction(String schemaName, int schemaVersion, String actionName, JSONObject actionParameters) throws ThingIFException {
-        Schema schema = this.getSchema(schemaName, schemaVersion);
-        if (schema == null) {
-            throw new UnsupportedSchemaException(schemaName, schemaVersion);
-        }
-        Class<? extends Action> actionClass = schema.getActionClass(actionName);
-        if (actionClass == null) {
-            throw new UnsupportedActionException(schemaName, schemaVersion, actionName);
-        }
-        String json = actionParameters == null ? "{}" : actionParameters.toString();
-        return this.deserialize(schema, json, actionClass);
-    }
-    private ActionResult generateActionResult(String schemaName, int schemaVersion, String actionName, JSONObject actionResult) throws ThingIFException {
-        Schema schema = this.getSchema(schemaName, schemaVersion);
-        if (schema == null) {
-            throw new UnsupportedSchemaException(schemaName, schemaVersion);
-        }
-        Class<? extends ActionResult> actionResultClass = schema.getActionResultClass(actionName);
-        if (actionResultClass == null) {
-            throw new UnsupportedActionException(schemaName, schemaVersion, actionName);
-        }
-        String json = actionResult == null ? "{}" : actionResult.toString();
-        return this.deserialize(schema, json, actionResultClass);
-    }
+
     private Map<String, String> newHeader() {
         Map<String, String> headers = new HashMap<String, String>();
         if (!TextUtils.isEmpty(this.getAppID())) {


### PR DESCRIPTION
In current implementation, Listing Command/ Trigger API throws exception when the schema of the item doesn't matches with ones registered in ThingIFAPI instance.
This would be tough for app developers.
- Since it require apps to remove or modify the schema of those items to retrieve other items.
- Or update app to accept new schema.

Those restriction would be too strict for real operation of the services.

To improve the situation, just ignore if list result contains schema which is not registered in ThingIFAPI instance.