### PR TITLE
Send sdk version in X-Kii-SDK header.

### DIFF
--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -1120,7 +1120,7 @@ public class ThingIFAPI implements Parcelable {
      */
     @NonNull
     public static String getSDKVersion() {
-        return ThingIFAPI.getSDKVersion();
+        return SDK_VERSION;
     }
 
 }

--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -48,6 +48,7 @@ import java.util.Map;
 public class ThingIFAPI implements Parcelable {
 
     private static final String SHARED_PREFERENCES_KEY_INSTANCE = "ThingIFAPI_INSTANCE";
+    private static final String SDK_VERSION = "0.10.0";
 
     private static Context context;
     private final String tag;
@@ -1111,6 +1112,15 @@ public class ThingIFAPI implements Parcelable {
         dest.writeParcelable(this.target, flags);
         dest.writeTypedList(new ArrayList<Schema>(this.schemas.values()));
         dest.writeString(this.installationID);
+    }
+
+    /**
+     * Get version of the SDK.
+     * @return Version string.
+     */
+    @NonNull
+    public static String getSDKVersion() {
+        return ThingIFAPI.getSDKVersion();
     }
 
 }

--- a/thingif/src/main/java/com/kii/thingif/internal/http/IoTRestRequest.java
+++ b/thingif/src/main/java/com/kii/thingif/internal/http/IoTRestRequest.java
@@ -1,12 +1,15 @@
 package com.kii.thingif.internal.http;
 
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import com.kii.thingif.ThingIFAPI;
 import com.squareup.okhttp.MediaType;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -31,6 +34,15 @@ public class IoTRestRequest {
                           @NonNull Map<String, String> headers) {
         this(url, method, headers, null, null);
     }
+
+    private static String getSDKInfo() {
+        StringBuilder builder = new StringBuilder();
+        builder.append("sn=at;") // at: Android Thing-IF
+                .append("sv=").append(ThingIFAPI.getSDKVersion()).append(";")
+                .append("pv=").append(Build.VERSION.SDK_INT);
+        return builder.toString();
+    }
+
     public IoTRestRequest(@NonNull String url,
                           @NonNull Method method,
                           @NonNull Map<String, String> headers,
@@ -38,7 +50,9 @@ public class IoTRestRequest {
                           @Nullable Object entity) {
         this.url = url;
         this.method = method;
-        this.headers = headers;
+        Map<String, String> modifiedHeaders = new HashMap<>(headers);
+        modifiedHeaders.put("X-Kii-SDK", getSDKInfo());
+        this.headers = modifiedHeaders;
         this.contentType = contentType;
         this.entity = entity;
     }


### PR DESCRIPTION
Added codes are Similar to KiiCloud SDKs.
- Http Header output of SDK info: X-Kii-SDK (For internal access log analytics.)
- ThingIFAPI#getSDKVersion() method is added. (Public method)