### PR TITLE
Change deleteTrigger API.

### DIFF
--- a/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_DeleteTriggerTest.java
+++ b/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_DeleteTriggerTest.java
@@ -57,22 +57,18 @@ public class ThingIFAPI_DeleteTriggerTest extends ThingIFAPITestBase {
         String deletedTrigerID = api.deleteTrigger(triggerID);
         // verify the result
         Assert.assertEquals(triggerID, deletedTrigerID);
-
-        // verify the 1st request
-        RecordedRequest request1 = this.server.takeRequest(1, TimeUnit.SECONDS);
-        Assert.assertEquals(BASE_PATH + "/targets/" + thingID.toString() + "/triggers/" + triggerID, request1.getPath());
-        Assert.assertEquals("GET", request1.getMethod());
+        
+        // verify the request
+        RecordedRequest request = this.server.takeRequest(1, TimeUnit.SECONDS);
+        Assert.assertEquals(BASE_PATH + "/targets/" + thingID.toString() + "/triggers/" + triggerID, request.getPath());
+        Assert.assertEquals("DELETE", request.getMethod());
 
         Map<String, String> expectedRequestHeaders = new HashMap<String, String>();
         expectedRequestHeaders.put("X-Kii-AppID", APP_ID);
         expectedRequestHeaders.put("X-Kii-AppKey", APP_KEY);
         expectedRequestHeaders.put("Authorization", "Bearer " + api.getOwner().getAccessToken());
-        this.assertRequestHeader(expectedRequestHeaders, request1);
-        // verify the 2nd request
-        RecordedRequest request2 = this.server.takeRequest(1, TimeUnit.SECONDS);
-        Assert.assertEquals(BASE_PATH + "/targets/" + thingID.toString() + "/triggers/" + triggerID, request2.getPath());
-        Assert.assertEquals("DELETE", request2.getMethod());
-        this.assertRequestHeader(expectedRequestHeaders, request2);
+        this.assertRequestHeader(expectedRequestHeaders, request);
+
     }
     @Test
     public void deleteTrigger403ErrorTest() throws Exception {
@@ -92,15 +88,15 @@ public class ThingIFAPI_DeleteTriggerTest extends ThingIFAPITestBase {
         } catch (ForbiddenException e) {
         }
         // verify the 1st request
-        RecordedRequest request1 = this.server.takeRequest(1, TimeUnit.SECONDS);
-        Assert.assertEquals(BASE_PATH + "/targets/" + thingID.toString() + "/triggers/" + triggerID, request1.getPath());
-        Assert.assertEquals("GET", request1.getMethod());
+        RecordedRequest request = this.server.takeRequest(1, TimeUnit.SECONDS);
+        Assert.assertEquals(BASE_PATH + "/targets/" + thingID.toString() + "/triggers/" + triggerID, request.getPath());
+        Assert.assertEquals("DELETE", request.getMethod());
 
         Map<String, String> expectedRequestHeaders = new HashMap<String, String>();
         expectedRequestHeaders.put("X-Kii-AppID", APP_ID);
         expectedRequestHeaders.put("X-Kii-AppKey", APP_KEY);
         expectedRequestHeaders.put("Authorization", "Bearer " + api.getOwner().getAccessToken());
-        this.assertRequestHeader(expectedRequestHeaders, request1);
+        this.assertRequestHeader(expectedRequestHeaders, request);
     }
     @Test
     public void deleteTrigger404ErrorTest() throws Exception {
@@ -120,15 +116,15 @@ public class ThingIFAPI_DeleteTriggerTest extends ThingIFAPITestBase {
         } catch (NotFoundException e) {
         }
         // verify the 1st request
-        RecordedRequest request1 = this.server.takeRequest(1, TimeUnit.SECONDS);
-        Assert.assertEquals(BASE_PATH + "/targets/" + thingID.toString() + "/triggers/" + triggerID, request1.getPath());
-        Assert.assertEquals("GET", request1.getMethod());
+        RecordedRequest request = this.server.takeRequest(1, TimeUnit.SECONDS);
+        Assert.assertEquals(BASE_PATH + "/targets/" + thingID.toString() + "/triggers/" + triggerID, request.getPath());
+        Assert.assertEquals("DELETE", request.getMethod());
 
         Map<String, String> expectedRequestHeaders = new HashMap<String, String>();
         expectedRequestHeaders.put("X-Kii-AppID", APP_ID);
         expectedRequestHeaders.put("X-Kii-AppKey", APP_KEY);
         expectedRequestHeaders.put("Authorization", "Bearer " + api.getOwner().getAccessToken());
-        this.assertRequestHeader(expectedRequestHeaders, request1);
+        this.assertRequestHeader(expectedRequestHeaders, request);
     }
     @Test
     public void deleteTrigger503ErrorTest() throws Exception {
@@ -148,15 +144,15 @@ public class ThingIFAPI_DeleteTriggerTest extends ThingIFAPITestBase {
         } catch (ServiceUnavailableException e) {
         }
         // verify the 1st request
-        RecordedRequest request1 = this.server.takeRequest(1, TimeUnit.SECONDS);
-        Assert.assertEquals(BASE_PATH + "/targets/" + thingID.toString() + "/triggers/" + triggerID, request1.getPath());
-        Assert.assertEquals("GET", request1.getMethod());
+        RecordedRequest request = this.server.takeRequest(1, TimeUnit.SECONDS);
+        Assert.assertEquals(BASE_PATH + "/targets/" + thingID.toString() + "/triggers/" + triggerID, request.getPath());
+        Assert.assertEquals("DELETE", request.getMethod());
 
         Map<String, String> expectedRequestHeaders = new HashMap<String, String>();
         expectedRequestHeaders.put("X-Kii-AppID", APP_ID);
         expectedRequestHeaders.put("X-Kii-AppKey", APP_KEY);
         expectedRequestHeaders.put("Authorization", "Bearer " + api.getOwner().getAccessToken());
-        this.assertRequestHeader(expectedRequestHeaders, request1);
+        this.assertRequestHeader(expectedRequestHeaders, request);
     }
     @Test(expected = IllegalStateException.class)
     public void deleteTriggerWithNullTargetTest() throws Exception {

--- a/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_DeleteTriggerTest.java
+++ b/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_DeleteTriggerTest.java
@@ -54,14 +54,10 @@ public class ThingIFAPI_DeleteTriggerTest extends ThingIFAPITestBase {
         this.addEmptyMockResponse(204);
 
         api.setTarget(target);
-        Trigger trigger = api.deleteTrigger(triggerID);
+        String deletedTrigerID = api.deleteTrigger(triggerID);
         // verify the result
-        Assert.assertEquals(triggerID, trigger.getTriggerID());
-        Assert.assertEquals(false, trigger.disabled());
-        Assert.assertNull(trigger.getDisabledReason());
-        Assert.assertFalse(trigger.disabled());
-        this.assertPredicate(predicate, trigger.getPredicate());
-        this.assertCommand(schema, expectedCommand, trigger.getCommand());
+        Assert.assertEquals(triggerID, deletedTrigerID);
+
         // verify the 1st request
         RecordedRequest request1 = this.server.takeRequest(1, TimeUnit.SECONDS);
         Assert.assertEquals(BASE_PATH + "/targets/" + thingID.toString() + "/triggers/" + triggerID, request1.getPath());

--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -844,13 +844,13 @@ public class ThingIFAPI implements Parcelable {
     /**
      * Delete the specified Trigger.
      * @param triggerID ID of the Trigger to be deleted.
-     * @return Deleted Trigger Instance.
+     * @return Deleted Trigger Id.
      * @throws ThingIFException Thrown when failed to connect IoT Cloud Server.
      * @throws ThingIFRestException Thrown when server returns error response.
      */
     @NonNull
     @WorkerThread
-    public Trigger deleteTrigger(
+    public String deleteTrigger(
             @NonNull String triggerID) throws
             ThingIFException {
 
@@ -861,13 +861,13 @@ public class ThingIFAPI implements Parcelable {
             throw new IllegalArgumentException("triggerID is null or empty");
         }
 
-        Trigger trigger = this.getTrigger(triggerID);
+
         String path = MessageFormat.format("/thing-if/apps/{0}/targets/{1}/triggers/{2}", this.app.getAppID(), target.getTypedID().toString(), triggerID);
         String url = Path.combine(this.app.getBaseUrl(), path);
         Map<String, String> headers = this.newHeader();
         IoTRestRequest request = new IoTRestRequest(url, IoTRestRequest.Method.DELETE, headers);
         this.restClient.sendRequest(request);
-        return trigger;
+        return triggerID;
     }
 
     /**


### PR DESCRIPTION
## API change (breaking backward compatibility)
- Class/File to be change : ThingIFAPI (ThingIFAPI.java)
  - Methods changed : ~~public Trigger deleteTrigger(@NonNull String triggerID) throws ThingIFException~~ 
 - Behaviour to change : ~~Make GET request every time before delete~~

- Change overview : 
  - Change methods signature return from `Trigger` to `String`
 ```java
 public String deleteTrigger(@NonNull String triggerID) throws ThingIFException
```

 - Behaviour change
    - Remove GET request 

## Implementations Change
- remove un necessary getTrigger call before deletion
- update test case.