### PR TITLE
Typo is fixed.

### DIFF
--- a/thingiftest/src/androidTest/java/com/kii/thingiftest/largetests/CommandTest.java
+++ b/thingiftest/src/androidTest/java/com/kii/thingiftest/largetests/CommandTest.java
@@ -9,7 +9,6 @@ import com.kii.thingif.ThingIFAPI;
 import com.kii.thingif.TypedID;
 import com.kii.thingif.command.Action;
 import com.kii.thingif.command.Command;
-import com.kii.thingiftest.largetests.LargeTestCaseBase;
 import com.kii.thingiftest.schema.SetBrightness;
 import com.kii.thingiftest.schema.SetColor;
 import com.kii.thingiftest.schema.SetColorTemperature;
@@ -29,7 +28,7 @@ import java.util.UUID;
 public class CommandTest extends LargeTestCaseBase {
     @Test
     public void basicTest() throws Exception {
-        ThingIFAPI api = this.craeteThingIFAPIWithDemoSchema();
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema();
         String vendorThingID = UUID.randomUUID().toString();
         String thingPassword = "password";
 
@@ -127,7 +126,7 @@ public class CommandTest extends LargeTestCaseBase {
     }
     @Test
     public void listCommandsEmptyResultTest() throws Exception {
-        ThingIFAPI api = this.craeteThingIFAPIWithDemoSchema();
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema();
         String vendorThingID = UUID.randomUUID().toString();
         String thingPassword = "password";
 

--- a/thingiftest/src/androidTest/java/com/kii/thingiftest/largetests/LargeTestCaseBase.java
+++ b/thingiftest/src/androidTest/java/com/kii/thingiftest/largetests/LargeTestCaseBase.java
@@ -10,7 +10,6 @@ import com.kii.cloud.rest.client.KiiRest;
 import com.kii.cloud.rest.client.model.storage.KiiNormalUser;
 import com.kii.thingif.KiiApp;
 import com.kii.thingif.Owner;
-import com.kii.thingif.Site;
 import com.kii.thingif.ThingIFAPI;
 import com.kii.thingif.ThingIFAPIBuilder;
 import com.kii.thingif.TypedID;
@@ -106,7 +105,7 @@ public abstract class LargeTestCaseBase extends AndroidTestCase {
         sb.addActionClass(TurnPower.class, TurnPowerResult.class);
         return sb.build();
     }
-    protected ThingIFAPI craeteThingIFAPIWithDemoSchema() throws Exception {
+    protected ThingIFAPI createThingIFAPIWithDemoSchema() throws Exception {
         Owner owner = this.createNewOwner();
         String hostname = server.getBaseUrl().substring("https://".length());
         KiiApp app = KiiApp.Builder.builderWithHostName(server.getAppID(), server.getAppKey(), hostname).build();

--- a/thingiftest/src/androidTest/java/com/kii/thingiftest/largetests/OneTimeTriggerTest.java
+++ b/thingiftest/src/androidTest/java/com/kii/thingiftest/largetests/OneTimeTriggerTest.java
@@ -25,7 +25,7 @@ import java.util.UUID;
 public class OneTimeTriggerTest extends LargeTestCaseBase {
     @Test
     public void basicScheduleOncePredicateTriggerTest() throws Exception {
-        ThingIFAPI api = this.craeteThingIFAPIWithDemoSchema();
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema();
         String vendorThingID = UUID.randomUUID().toString();
         String thingPassword = "password";
 

--- a/thingiftest/src/androidTest/java/com/kii/thingiftest/largetests/PushTest.java
+++ b/thingiftest/src/androidTest/java/com/kii/thingiftest/largetests/PushTest.java
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith;
 public class PushTest extends LargeTestCaseBase {
     @Test
     public void basicTest() throws Exception {
-        ThingIFAPI api = this.craeteThingIFAPIWithDemoSchema();
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema();
         String installationID = api.installPush("GCM-REGISTRATION-ID", PushBackend.GCM);
         api.uninstallPush(installationID);
     }

--- a/thingiftest/src/androidTest/java/com/kii/thingiftest/largetests/TriggerTest.java
+++ b/thingiftest/src/androidTest/java/com/kii/thingiftest/largetests/TriggerTest.java
@@ -41,7 +41,7 @@ import java.util.UUID;
 public class TriggerTest extends LargeTestCaseBase {
     @Test
     public void basicStatePredicateTriggerTest() throws Exception {
-        ThingIFAPI api = this.craeteThingIFAPIWithDemoSchema();
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema();
         String vendorThingID = UUID.randomUUID().toString();
         String thingPassword = "password";
 
@@ -262,7 +262,7 @@ public class TriggerTest extends LargeTestCaseBase {
     }
     @Test
     public void basicServerCodeTriggerTest() throws Exception {
-        ThingIFAPI api = this.craeteThingIFAPIWithDemoSchema();
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema();
         String vendorThingID = UUID.randomUUID().toString();
         String thingPassword = "password";
 
@@ -443,7 +443,7 @@ public class TriggerTest extends LargeTestCaseBase {
     }
     @Test
     public void listTriggersEmptyResultTest() throws Exception {
-        ThingIFAPI api = this.craeteThingIFAPIWithDemoSchema();
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema();
         String vendorThingID = UUID.randomUUID().toString();
         String thingPassword = "password";
 
@@ -475,7 +475,7 @@ public class TriggerTest extends LargeTestCaseBase {
         rest.api().servercode().setCurrentVersion(versionID);
 
         // initialize ThingIFAPI
-        ThingIFAPI api = this.craeteThingIFAPIWithDemoSchema();
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema();
         String vendorThingID = UUID.randomUUID().toString();
         String thingPassword = "password";
 
@@ -547,7 +547,7 @@ public class TriggerTest extends LargeTestCaseBase {
         rest.api().servercode().setCurrentVersion(versionID);
 
         // initialize ThingIFAPI
-        ThingIFAPI api = this.craeteThingIFAPIWithDemoSchema();
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema();
         String vendorThingID = UUID.randomUUID().toString();
         String thingPassword = "password";
 


### PR DESCRIPTION
I renamed `craeteThingIFAPIWithDemoSchema` to `createThingIFAPIWithDemoSchema` because this is typo. But riza rollbacked this fix at 8616087a3961a35be587dfff83e05c6829f31a61

I renamed again.