### PR TITLE
accessToken field in GatewayAPIBuilder is removed.

### DIFF
--- a/thingif/src/main/java/com/kii/thingif/gateway/GatewayAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/gateway/GatewayAPI.java
@@ -49,20 +49,12 @@ public class GatewayAPI implements Parcelable {
                @Nullable String tag,
                @NonNull KiiApp app,
                @NonNull Uri gatewayAddress) {
-        this(context, tag, app, gatewayAddress, null);
-    }
-    GatewayAPI(@Nullable Context context,
-               @Nullable String tag,
-               @NonNull KiiApp app,
-               @NonNull Uri gatewayAddress,
-               @Nullable String accessToken) {
         if (context != null) {
             GatewayAPI.context = context.getApplicationContext();
         }
         this.app = app;
         this.tag =tag;
         this.gatewayAddress = gatewayAddress;
-        this.accessToken = accessToken;
         this.restClient = new IoTRestClient();
     }
 
@@ -425,12 +417,11 @@ public class GatewayAPI implements Parcelable {
      */
     @NonNull
     public static GatewayAPI loadFromStoredInstance(@NonNull Context context, @Nullable String tag) throws StoredGatewayAPIInstanceNotFoundException {
+        GatewayAPI.context = context.getApplicationContext();
         SharedPreferences preferences = getSharedPreferences();
         String serializedJson = preferences.getString(getSharedPreferencesKey(tag), null);
         if (serializedJson != null) {
-            GatewayAPI retval = GsonRepository.gson().fromJson(serializedJson, GatewayAPI.class);
-            GatewayAPI.context = context.getApplicationContext();
-            return retval;
+            return  GsonRepository.gson().fromJson(serializedJson, GatewayAPI.class);
         }
         throw new StoredGatewayAPIInstanceNotFoundException(tag);
     }
@@ -462,7 +453,6 @@ public class GatewayAPI implements Parcelable {
             editor.apply();
         }
     }
-
     private static String getSharedPreferencesKey(String tag) {
         return SHARED_PREFERENCES_KEY_INSTANCE + (tag == null ? "" : "_"  +tag);
     }

--- a/thingif/src/main/java/com/kii/thingif/gateway/GatewayAPIBuilder.java
+++ b/thingif/src/main/java/com/kii/thingif/gateway/GatewayAPIBuilder.java
@@ -14,7 +14,6 @@ public class GatewayAPIBuilder {
     private String tag;
     private final KiiApp app;
     private final Uri gatewayAddress;
-    private String accessToken;
 
     private GatewayAPIBuilder(
             @Nullable Context context,
@@ -68,31 +67,6 @@ public class GatewayAPIBuilder {
         }
         return new GatewayAPIBuilder(context, app, gatewayAddress);
     }
-    /**
-     * Instantiate new GatewayAPIBuilder without Context.
-     * This method is for internal use only. Do not call it from your application.
-     *
-     * @param app Kii Cloud Application.
-     * @param gatewayAddress Gateway Address
-     * @return ThingIFAPIBuilder instance.
-     */
-    @NonNull
-    public static GatewayAPIBuilder _newBuilder(
-            @NonNull KiiApp app,
-            @NonNull Uri gatewayAddress) {
-        if (app == null) {
-            throw new IllegalArgumentException("app is null");
-        }
-        if (gatewayAddress == null) {
-            throw new IllegalArgumentException("gatewayAddress is null");
-        }
-        return new GatewayAPIBuilder(null, app, gatewayAddress);
-    }
-
-    public GatewayAPIBuilder setAccessToken(String accessToken) {
-        this.accessToken = accessToken;
-        return this;
-    }
 
     /**
      * Instantiate new GatewayAPI instance.
@@ -102,7 +76,6 @@ public class GatewayAPIBuilder {
     @NonNull
     public GatewayAPI build() {
         GatewayAPI api = new GatewayAPI(this.context, this.tag, this.app, this.gatewayAddress);
-        api.setAccessToken(this.accessToken);
         return api;
     }
 }

--- a/thingif/src/main/java/com/kii/thingif/internal/GsonRepository.java
+++ b/thingif/src/main/java/com/kii/thingif/internal/GsonRepository.java
@@ -19,22 +19,20 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import com.kii.thingif.KiiApp;
+import com.kii.thingif.Owner;
 import com.kii.thingif.ServerError;
 import com.kii.thingif.StandaloneThing;
+import com.kii.thingif.Target;
+import com.kii.thingif.TargetState;
 import com.kii.thingif.TargetThing;
 import com.kii.thingif.ThingIFAPI;
 import com.kii.thingif.ThingIFAPIBuilder;
-import com.kii.thingif.Owner;
-import com.kii.thingif.Target;
-import com.kii.thingif.TargetState;
 import com.kii.thingif.TypedID;
 import com.kii.thingif.command.Action;
 import com.kii.thingif.command.ActionResult;
 import com.kii.thingif.exception.UnsupportedActionException;
 import com.kii.thingif.gateway.EndNode;
 import com.kii.thingif.gateway.Gateway;
-import com.kii.thingif.gateway.GatewayAPI;
-import com.kii.thingif.gateway.GatewayAPIBuilder;
 import com.kii.thingif.schema.Schema;
 import com.kii.thingif.schema.SchemaBuilder;
 import com.kii.thingif.trigger.Condition;
@@ -47,10 +45,10 @@ import com.kii.thingif.trigger.StatePredicate;
 import com.kii.thingif.trigger.TriggeredServerCodeResult;
 import com.kii.thingif.trigger.TriggersWhen;
 import com.kii.thingif.trigger.clause.And;
+import com.kii.thingif.trigger.clause.Clause;
 import com.kii.thingif.trigger.clause.Equals;
 import com.kii.thingif.trigger.clause.NotEquals;
 import com.kii.thingif.trigger.clause.Or;
-import com.kii.thingif.trigger.clause.Clause;
 import com.kii.thingif.trigger.clause.Range;
 
 import org.json.JSONArray;
@@ -481,6 +479,26 @@ public class GsonRepository {
         }
     };
 
+    private static final JsonSerializer<Uri> URI_SERIALIZER = new JsonSerializer<Uri>() {
+        @Override
+        public JsonElement serialize(Uri src, Type typeOfSrc, JsonSerializationContext context) {
+            JsonObject json = new JsonObject();
+            json.addProperty("uri", src.toString());
+            return json;
+        }
+    };
+
+    private static final JsonDeserializer<Uri> URI_DESERIALIZER = new JsonDeserializer<Uri>() {
+        @Override
+        public Uri deserialize(JsonElement jsonElement, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+            JsonObject json = (JsonObject)jsonElement;
+            if (json.has("uri")) {
+                return Uri.parse(json.get("uri").getAsString());
+            }
+            return null;
+        }
+    };
+
     static {
         DEFAULT_GSON = new GsonBuilder()
                 .registerTypeAdapter(JSONObject.class, ORG_JSON_OBJECT_SERIALIZER)
@@ -505,6 +523,8 @@ public class GsonRepository {
                 .registerTypeAdapter(StandaloneThing.class, TARGET_SERIALIZER)
                 .registerTypeAdapter(Gateway.class, TARGET_SERIALIZER)
                 .registerTypeAdapter(EndNode.class, TARGET_SERIALIZER)
+                .registerTypeAdapter(Uri.class, URI_SERIALIZER)
+                .registerTypeAdapter(Uri.class, URI_DESERIALIZER)
                 .create();
     }
 
@@ -594,6 +614,8 @@ public class GsonRepository {
                     .registerTypeAdapter(StandaloneThing.class, TARGET_SERIALIZER)
                     .registerTypeAdapter(Gateway.class, TARGET_SERIALIZER)
                     .registerTypeAdapter(EndNode.class, TARGET_SERIALIZER)
+                    .registerTypeAdapter(Uri.class, URI_SERIALIZER)
+                    .registerTypeAdapter(Uri.class, URI_DESERIALIZER)
                     .create();
             REPOSITORY.put(new Pair<String, Integer>(schema.getSchemaName(), schema.getSchemaVersion()), gson);
         }

--- a/thingif/src/main/java/com/kii/thingif/internal/GsonRepository.java
+++ b/thingif/src/main/java/com/kii/thingif/internal/GsonRepository.java
@@ -347,46 +347,6 @@ public class GsonRepository {
             return builder.build();
         }
     };
-    private static final JsonSerializer<GatewayAPI> GATEWAY_API_SERIALIZER = new JsonSerializer<GatewayAPI>() {
-        @Override
-        public JsonElement serialize(GatewayAPI src, Type typeOfSrc, JsonSerializationContext context) {
-            if (src == null) {
-                return null;
-            }
-            JsonObject json = new JsonObject();
-            json.add("app", DEFAULT_GSON.toJsonTree(src.getApp()));
-            json.addProperty("gatewayAddress", src.getGatewayAddress().toString());
-
-            String tag = src.getTag();
-            if (!TextUtils.isEmpty(tag)) {
-                json.addProperty("tag", tag);
-            }
-            json.addProperty("accessToken", src.getAccessToken());
-            return json;
-        }
-    };
-    private static final JsonDeserializer<GatewayAPI> GATEWAY_API_DESERIALIZER = new JsonDeserializer<GatewayAPI>() {
-        @Override
-        public GatewayAPI deserialize(JsonElement jsonElement, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-            if (jsonElement == null) {
-                return null;
-            }
-            JsonObject json = (JsonObject)jsonElement;
-            KiiApp app = DEFAULT_GSON.fromJson(json.getAsJsonObject("app"), KiiApp.class);
-            Uri gatewayAddress = Uri.parse(json.get("gatewayAddress").getAsString());
-            String tag = null;
-            if (json.has("tag")) {
-                tag = json.get("tag").getAsString();
-            }
-
-            GatewayAPIBuilder builder = GatewayAPIBuilder._newBuilder(app, gatewayAddress);
-            if (json.has("accessToken")) {
-                builder.setAccessToken(json.get("accessToken").getAsString());
-            }
-            builder.setTag(tag);
-            return builder.build();
-        }
-    };
     private static final JsonSerializer<TriggeredServerCodeResult> TRIGGERED_SERVER_CODE_RESULT_SERIALIZER = new JsonSerializer<TriggeredServerCodeResult>() {
         @Override
         public JsonElement serialize(TriggeredServerCodeResult src, Type typeOfSrc, JsonSerializationContext context) {
@@ -539,8 +499,6 @@ public class GsonRepository {
                 .registerTypeAdapter(Schema.class, SCHEMA_DESERIALIZER)
                 .registerTypeAdapter(ThingIFAPI.class, IOT_CLOUD_API_SERIALIZER)
                 .registerTypeAdapter(ThingIFAPI.class, IOT_CLOUD_API_DESERIALIZER)
-                .registerTypeAdapter(GatewayAPI.class, GATEWAY_API_SERIALIZER)
-                .registerTypeAdapter(GatewayAPI.class, GATEWAY_API_DESERIALIZER)
                 .registerTypeAdapter(TriggeredServerCodeResult.class, TRIGGERED_SERVER_CODE_RESULT_SERIALIZER)
                 .registerTypeAdapter(TriggeredServerCodeResult.class, TRIGGERED_SERVER_CODE_RESULT_DESERIALIZER)
                 .registerTypeAdapter(Target.class, TARGET_DESERIALIZER)
@@ -630,8 +588,6 @@ public class GsonRepository {
                     .registerTypeAdapter(Schema.class, SCHEMA_DESERIALIZER)
                     .registerTypeAdapter(ThingIFAPI.class, IOT_CLOUD_API_SERIALIZER)
                     .registerTypeAdapter(ThingIFAPI.class, IOT_CLOUD_API_DESERIALIZER)
-                    .registerTypeAdapter(GatewayAPI.class, GATEWAY_API_SERIALIZER)
-                    .registerTypeAdapter(GatewayAPI.class, GATEWAY_API_DESERIALIZER)
                     .registerTypeAdapter(TriggeredServerCodeResult.class, TRIGGERED_SERVER_CODE_RESULT_SERIALIZER)
                     .registerTypeAdapter(TriggeredServerCodeResult.class, TRIGGERED_SERVER_CODE_RESULT_DESERIALIZER)
                     .registerTypeAdapter(Target.class, TARGET_DESERIALIZER)


### PR DESCRIPTION
Access token in `GatewayAPI` class is retrieved by `GatewayAPI#login()` method, so GatewayAPIBuilder does not need to have `accessToken` field.

This PR have following changes:

  * accessToken fields in GatewayAPIBuilder is removed.
  * Gson serializer and deserializer for GatewayAPI are move from `GsonRepository ` class to `GatewayAPI` class.

Deserializing `GatewayAPI` in `GsonRepository` causes accessToken field in `GatewayAPI` makes public. So I moved serializer and deserializer to `GatewayAPI` class.