### PR TITLE
Small tests for onboarding with options are added.

### DIFF
--- a/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_OnBoardTest.java
+++ b/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_OnBoardTest.java
@@ -164,7 +164,7 @@ public class ThingIFAPI_OnBoardTest extends ThingIFAPITestBase {
         expectedRequestBody.add("thingProperties", new JsonParser().parse(thingProperties.toString()));
         this.assertRequestBody(expectedRequestBody, request);
     }
-    @Test(expected = IllegalStateException.class)
+    @Test
     public void onboardTwiceTest() throws Exception {
         String vendorThingID = "v1234567890abcde";
         String thingPassword = "password";
@@ -177,8 +177,13 @@ public class ThingIFAPI_OnBoardTest extends ThingIFAPITestBase {
         ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
         Assert.assertFalse(api.onboarded());
         Target target = api.onboard(vendorThingID, thingPassword, DEMO_THING_TYPE, thingProperties);
+        Assert.assertNotNull(target);
         Assert.assertTrue(api.onboarded());
-        target = api.onboard(vendorThingID, thingPassword, DEMO_THING_TYPE, thingProperties);
+        try {
+            api.onboard(vendorThingID, thingPassword, DEMO_THING_TYPE, thingProperties);
+            Assert.fail("ThingIFRestException should be thrown");
+        } catch (IllegalStateException e) {
+        }
     }
     @Test(expected = IllegalArgumentException.class)
     public void onboardWithVendorThingIDByOwnerWithNullVendorThingIDTest() throws Exception {
@@ -294,5 +299,296 @@ public class ThingIFAPI_OnBoardTest extends ThingIFAPITestBase {
     public void onboardWithThingIDByOwnerTestWithEmptyPasswordTest() throws Exception {
         ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
         Target target = api.onboard("th.1234567890", "");
+    }
+
+    @Test
+    public void onboardWithVendorThingIDAndOptionsTest() throws Exception {
+        String vendorThingID = "v1234567890abcde";
+        String thingPassword = "password";
+        JSONObject thingProperties = new JSONObject();
+        thingProperties.put("manufacturer", "Kii");
+        String thingID = "th.1234567890";
+        String accessToken = "thing-access-token-1234";
+        OnboardWithVendorThingIDOptions.Builder options = new OnboardWithVendorThingIDOptions.Builder();
+        options.setThingType(DEMO_THING_TYPE)
+                .setFirmwareVersion("dummyVersion")
+                .setThingProperties(thingProperties)
+                .setLayoutPosition(LayoutPosition.STANDALONE)
+                .setDataGroupingInterval(DataGroupingInterval.INTERVAL_1_MINUTE);
+        this.addMockResponseForOnBoard(200, thingID, accessToken);
+
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        Assert.assertFalse(api.onboarded());
+        Target target = api.onboard(vendorThingID, thingPassword, options.build());
+        Assert.assertTrue(api.onboarded());
+
+        // verify the result
+        Assert.assertEquals(new TypedID(TypedID.Types.THING, thingID), target.getTypedID());
+        Assert.assertEquals(accessToken, target.getAccessToken());
+        // verify the request
+        RecordedRequest request = this.server.takeRequest(1, TimeUnit.SECONDS);
+        Assert.assertEquals(BASE_PATH + "/onboardings", request.getPath());
+        Assert.assertEquals("POST", request.getMethod());
+
+        Map<String, String> expectedRequestHeaders = new HashMap<String, String>();
+        expectedRequestHeaders.put("X-Kii-AppID", APP_ID);
+        expectedRequestHeaders.put("X-Kii-AppKey", APP_KEY);
+        expectedRequestHeaders.put("Authorization", "Bearer " + api.getOwner().getAccessToken());
+        expectedRequestHeaders.put("Content-Type", "application/vnd.kii.OnboardingWithVendorThingIDByOwner+json");
+        this.assertRequestHeader(expectedRequestHeaders, request);
+
+        JsonObject expectedRequestBody = new JsonObject();
+        expectedRequestBody.addProperty("owner", api.getOwner().getTypedID().toString());
+        expectedRequestBody.addProperty("vendorThingID", vendorThingID);
+        expectedRequestBody.addProperty("thingPassword", thingPassword);
+        expectedRequestBody.addProperty("thingType", DEMO_THING_TYPE);
+        expectedRequestBody.addProperty("firmwareVersion", "dummyVersion");
+        expectedRequestBody.add("thingProperties", new JsonParser().parse(thingProperties.toString()));
+        expectedRequestBody.addProperty("layoutPosition", "STANDALONE");
+        expectedRequestBody.addProperty("dataGroupingInterval", "1_MINUTE");
+        this.assertRequestBody(expectedRequestBody, request);
+    }
+    @Test
+    public void onboardWithVendorThingIDAndOptions403ErrorTest() throws Exception {
+        String vendorThingID = "v1234567890abcde";
+        String thingPassword = "password";
+        JSONObject thingProperties = new JSONObject();
+        thingProperties.put("manufacturer", "Kii");
+        OnboardWithVendorThingIDOptions.Builder options = new OnboardWithVendorThingIDOptions.Builder();
+        options.setThingType(DEMO_THING_TYPE)
+                .setThingProperties(thingProperties)
+                .setLayoutPosition(LayoutPosition.GATEWAY)
+                .setDataGroupingInterval(DataGroupingInterval.INTERVAL_15_MINUTES);
+        this.addEmptyMockResponse(403);
+
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        try {
+            api.onboard(vendorThingID, thingPassword, options.build());
+            Assert.fail("ThingIFRestException should be thrown");
+        } catch (ForbiddenException e) {
+        }
+        // verify the request
+        RecordedRequest request = this.server.takeRequest(1, TimeUnit.SECONDS);
+        Assert.assertEquals(BASE_PATH + "/onboardings", request.getPath());
+        Assert.assertEquals("POST", request.getMethod());
+
+        Map<String, String> expectedRequestHeaders = new HashMap<String, String>();
+        expectedRequestHeaders.put("X-Kii-AppID", APP_ID);
+        expectedRequestHeaders.put("X-Kii-AppKey", APP_KEY);
+        expectedRequestHeaders.put("Authorization", "Bearer " + api.getOwner().getAccessToken());
+        expectedRequestHeaders.put("Content-Type", "application/vnd.kii.OnboardingWithVendorThingIDByOwner+json");
+        this.assertRequestHeader(expectedRequestHeaders, request);
+
+        JsonObject expectedRequestBody = new JsonObject();
+        expectedRequestBody.addProperty("owner", api.getOwner().getTypedID().toString());
+        expectedRequestBody.addProperty("vendorThingID", vendorThingID);
+        expectedRequestBody.addProperty("thingPassword", thingPassword);
+        expectedRequestBody.addProperty("thingType", DEMO_THING_TYPE);
+        expectedRequestBody.add("thingProperties", new JsonParser().parse(thingProperties.toString()));
+        expectedRequestBody.addProperty("layoutPosition", "GATEWAY");
+        expectedRequestBody.addProperty("dataGroupingInterval", "15_MINUTES");
+        this.assertRequestBody(expectedRequestBody, request);
+    }
+    @Test
+    public void onboardWithVendorThingIDAndOptions404ErrorTest() throws Exception {
+        String vendorThingID = "v1234567890abcde";
+        String thingPassword = "password";
+        JSONObject thingProperties = new JSONObject();
+        thingProperties.put("manufacturer", "Kii");
+        OnboardWithVendorThingIDOptions.Builder options = new OnboardWithVendorThingIDOptions.Builder();
+        options.setThingType(DEMO_THING_TYPE)
+                .setThingProperties(thingProperties)
+                .setLayoutPosition(LayoutPosition.ENDNODE)
+                .setDataGroupingInterval(DataGroupingInterval.INTERVAL_30_MINUTES);
+        this.addEmptyMockResponse(404);
+
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        try {
+            api.onboard(vendorThingID, thingPassword, options.build());
+            Assert.fail("ThingIFRestException should be thrown");
+        } catch (NotFoundException e) {
+        }
+        // verify the request
+        RecordedRequest request = this.server.takeRequest(1, TimeUnit.SECONDS);
+        Assert.assertEquals(BASE_PATH + "/onboardings", request.getPath());
+        Assert.assertEquals("POST", request.getMethod());
+
+        Map<String, String> expectedRequestHeaders = new HashMap<String, String>();
+        expectedRequestHeaders.put("X-Kii-AppID", APP_ID);
+        expectedRequestHeaders.put("X-Kii-AppKey", APP_KEY);
+        expectedRequestHeaders.put("Authorization", "Bearer " + api.getOwner().getAccessToken());
+        expectedRequestHeaders.put("Content-Type", "application/vnd.kii.OnboardingWithVendorThingIDByOwner+json");
+        this.assertRequestHeader(expectedRequestHeaders, request);
+
+        JsonObject expectedRequestBody = new JsonObject();
+        expectedRequestBody.addProperty("owner", api.getOwner().getTypedID().toString());
+        expectedRequestBody.addProperty("vendorThingID", vendorThingID);
+        expectedRequestBody.addProperty("thingPassword", thingPassword);
+        expectedRequestBody.addProperty("thingType", DEMO_THING_TYPE);
+        expectedRequestBody.add("thingProperties", new JsonParser().parse(thingProperties.toString()));
+        expectedRequestBody.addProperty("layoutPosition", "ENDNODE");
+        expectedRequestBody.addProperty("dataGroupingInterval", "30_MINUTES");
+        this.assertRequestBody(expectedRequestBody, request);
+    }
+    @Test
+    public void onboardWithVendorThingIDAndOptions500ErrorTest() throws Exception {
+        String vendorThingID = "v1234567890abcde";
+        String thingPassword = "password";
+        JSONObject thingProperties = new JSONObject();
+        thingProperties.put("manufacturer", "Kii");
+        OnboardWithVendorThingIDOptions.Builder options = new OnboardWithVendorThingIDOptions.Builder();
+        options.setThingType(DEMO_THING_TYPE)
+                .setThingProperties(thingProperties)
+                .setLayoutPosition(LayoutPosition.STANDALONE)
+                .setDataGroupingInterval(DataGroupingInterval.INTERVAL_1_HOUR);
+        this.addEmptyMockResponse(500);
+
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        try {
+            api.onboard(vendorThingID, thingPassword, options.build());
+            Assert.fail("ThingIFRestException should be thrown");
+        } catch (InternalServerErrorException e) {
+        }
+        // verify the request
+        RecordedRequest request = this.server.takeRequest(1, TimeUnit.SECONDS);
+        Assert.assertEquals(BASE_PATH + "/onboardings", request.getPath());
+        Assert.assertEquals("POST", request.getMethod());
+
+        Map<String, String> expectedRequestHeaders = new HashMap<String, String>();
+        expectedRequestHeaders.put("X-Kii-AppID", APP_ID);
+        expectedRequestHeaders.put("X-Kii-AppKey", APP_KEY);
+        expectedRequestHeaders.put("Authorization", "Bearer " + api.getOwner().getAccessToken());
+        expectedRequestHeaders.put("Content-Type", "application/vnd.kii.OnboardingWithVendorThingIDByOwner+json");
+        this.assertRequestHeader(expectedRequestHeaders, request);
+
+        JsonObject expectedRequestBody = new JsonObject();
+        expectedRequestBody.addProperty("owner", api.getOwner().getTypedID().toString());
+        expectedRequestBody.addProperty("vendorThingID", vendorThingID);
+        expectedRequestBody.addProperty("thingPassword", thingPassword);
+        expectedRequestBody.addProperty("thingType", DEMO_THING_TYPE);
+        expectedRequestBody.add("thingProperties", new JsonParser().parse(thingProperties.toString()));
+        expectedRequestBody.addProperty("layoutPosition", "STANDALONE");
+        expectedRequestBody.addProperty("dataGroupingInterval", "1_HOUR");
+        this.assertRequestBody(expectedRequestBody, request);
+    }
+    @Test
+    public void onboardWithVendorThingIDAndOptionsTwiceTest() throws Exception {
+        String vendorThingID = "v1234567890abcde";
+        String thingPassword = "password";
+        JSONObject thingProperties = new JSONObject();
+        thingProperties.put("manufacturer", "Kii");
+        String thingID = "th.1234567890";
+        String accessToken = "thing-access-token-1234";
+        OnboardWithVendorThingIDOptions.Builder options = new OnboardWithVendorThingIDOptions.Builder();
+        options.setThingType(DEMO_THING_TYPE)
+                .setThingProperties(thingProperties);
+        this.addMockResponseForOnBoard(200, thingID, accessToken);
+
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        Assert.assertFalse(api.onboarded());
+        Target target = api.onboard(vendorThingID, thingPassword, options.build());
+        Assert.assertNotNull(target);
+        Assert.assertTrue(api.onboarded());
+        try {
+            api.onboard(vendorThingID, thingPassword, options.build());
+            Assert.fail("IllegalStateException should be thrown");
+        } catch (IllegalStateException e) {
+        }
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void onboardWithVendorThingIDAndOptionsWithNullVendorThingIDTest() throws Exception {
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        Target target = api.onboard(null, "password", (OnboardWithVendorThingIDOptions) null);
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void onboardWithVendorThingIDAndOptionsWithEmptyVendorThingIDTest() throws Exception {
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        Target target = api.onboard("", "password", (OnboardWithVendorThingIDOptions) null);
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void onboardWithVendorThingIDAndOptionsWithNullVendorThingPasswordTest() throws Exception {
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        Target target = api.onboard("v1234567890abcde", null, (OnboardWithVendorThingIDOptions) null);
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void onboardWithVendorThingIDAndOptionsWithEmptyVendorThingPasswordTest() throws Exception {
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        Target target = api.onboard("v1234567890abcde", "", (OnboardWithVendorThingIDOptions) null);
+    }
+    @Test
+    public void onboardWithThingIDAndOptionsTest() throws Exception {
+        String thingID = "th.1234567890";
+        String thingPassword = "password";
+        String accessToken = "thing-access-token-1234";
+        OnboardWithThingIDOptions.Builder options = new OnboardWithThingIDOptions.Builder();
+        options.setLayoutPosition(LayoutPosition.STANDALONE)
+                .setDataGroupingInterval(DataGroupingInterval.INTERVAL_12_HOURS);
+        this.addMockResponseForOnBoard(200, thingID, accessToken);
+
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        Assert.assertFalse(api.onboarded());
+        Target target = api.onboard(thingID, thingPassword, options.build());
+        Assert.assertTrue(api.onboarded());
+
+        // verify the result
+        Assert.assertEquals(new TypedID(TypedID.Types.THING, thingID), target.getTypedID());
+        Assert.assertEquals(accessToken, target.getAccessToken());
+        // verify the request
+        RecordedRequest request = this.server.takeRequest(1, TimeUnit.SECONDS);
+        Assert.assertEquals(BASE_PATH + "/onboardings", request.getPath());
+        Assert.assertEquals("POST", request.getMethod());
+
+        Map<String, String> expectedRequestHeaders = new HashMap<String, String>();
+        expectedRequestHeaders.put("X-Kii-AppID", APP_ID);
+        expectedRequestHeaders.put("X-Kii-AppKey", APP_KEY);
+        expectedRequestHeaders.put("Authorization", "Bearer " + api.getOwner().getAccessToken());
+        expectedRequestHeaders.put("Content-Type", "application/vnd.kii.OnboardingWithThingIDByOwner+json");
+        this.assertRequestHeader(expectedRequestHeaders, request);
+
+        JsonObject expectedRequestBody = new JsonObject();
+        expectedRequestBody.addProperty("owner", api.getOwner().getTypedID().toString());
+        expectedRequestBody.addProperty("dataGroupingInterval", "12_HOURS");
+        expectedRequestBody.addProperty("thingID", thingID);
+        expectedRequestBody.addProperty("layoutPosition", "STANDALONE");
+        expectedRequestBody.addProperty("thingPassword", thingPassword);
+        this.assertRequestBody(expectedRequestBody, request);
+    }
+    @Test(expected = ForbiddenException.class)
+    public void onboardWithThingIDAndOptions403ErrorTest() throws Exception {
+        this.addMockResponseForOnBoard(403, null, null);
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        api.onboard("th.1234567890", "password", (OnboardWithThingIDOptions) null);
+    }
+    @Test(expected = NotFoundException.class)
+    public void onboardWithThingIDAndOptions404ErrorTest() throws Exception {
+        this.addMockResponseForOnBoard(404, null, null);
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        api.onboard("th.1234567890", "password", (OnboardWithThingIDOptions) null);
+    }
+    @Test(expected = InternalServerErrorException.class)
+    public void onboardWithThingIDAndOptions500ErrorTest() throws Exception {
+        this.addMockResponseForOnBoard(500, null, null);
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        api.onboard("th.1234567890", "password", (OnboardWithThingIDOptions) null);
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void onboardWithThingIDAndOptionsTestWithNullThingIDTest() throws Exception {
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        Target target = api.onboard(null, "password", (OnboardWithThingIDOptions) null);
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void onboardWithThingIDAndOptionsTestWithEmptyThingIDTest() throws Exception {
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        Target target = api.onboard("", "password", (OnboardWithThingIDOptions) null);
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void onboardWithThingIDAndOptionsTestWithNullPasswordTest() throws Exception {
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        Target target = api.onboard("th.1234567890", null, (OnboardWithThingIDOptions) null);
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void onboardWithThingIDAndOptionsTestWithEmptyPasswordTest() throws Exception {
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        Target target = api.onboard("th.1234567890", "", (OnboardWithThingIDOptions) null);
     }
 }

--- a/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_OnboardEndnodeWithGatewayTest.java
+++ b/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_OnboardEndnodeWithGatewayTest.java
@@ -209,4 +209,209 @@ public class ThingIFAPI_OnboardEndnodeWithGatewayTest extends ThingIFAPITestBase
         api.setTarget(new Gateway("gateway-thing-id", "gateway-vendor-thing-id"));
         Target target = api.onboardEndnodeWithGateway(new PendingEndNode("v1234567890abcde", DEMO_THING_TYPE, null), "");
     }
+    @Test
+    public void onboardEndnodeWithGatewayOptionsTest() throws Exception {
+        String gatewayThingID = UUID.randomUUID().toString();
+        String gatewayVendorThingID = UUID.randomUUID().toString();
+        String vendorThingID = UUID.randomUUID().toString();
+        String thingPassword = "password";
+        JSONObject thingProperties = new JSONObject();
+        thingProperties.put("manufacturer", "Kii");
+        String thingID = "th.1234567890";
+        String accessToken = "thing-access-token-1234";
+        OnboardEndnodeWithGatewayOptions.Builder options = new OnboardEndnodeWithGatewayOptions.Builder();
+        options.setDataGroupingInterval(DataGroupingInterval.INTERVAL_1_MINUTE);
+        this.addMockResponseForOnBoardEndnode(200, thingID, accessToken);
+
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        api.setTarget(new Gateway(gatewayThingID, gatewayVendorThingID));
+        Assert.assertTrue(api.onboarded());
+        EndNode target = api.onboardEndnodeWithGateway(
+                new PendingEndNode(vendorThingID, DEMO_THING_TYPE, thingProperties),
+                thingPassword, options.build());
+        Assert.assertTrue(api.onboarded());
+
+        // verify the result
+        Assert.assertEquals(new TypedID(TypedID.Types.THING, thingID), target.getTypedID());
+        Assert.assertEquals(accessToken, target.getAccessToken());
+        // verify the request
+        RecordedRequest request = this.server.takeRequest(1, TimeUnit.SECONDS);
+        Assert.assertEquals(BASE_PATH + "/onboardings", request.getPath());
+        Assert.assertEquals("POST", request.getMethod());
+
+        Map<String, String> expectedRequestHeaders = new HashMap<String, String>();
+        expectedRequestHeaders.put("X-Kii-AppID", APP_ID);
+        expectedRequestHeaders.put("X-Kii-AppKey", APP_KEY);
+        expectedRequestHeaders.put("Authorization", "Bearer " + api.getOwner().getAccessToken());
+        expectedRequestHeaders.put("Content-Type", "application/vnd.kii.OnboardingEndNodeWithGatewayThingID+json");
+        this.assertRequestHeader(expectedRequestHeaders, request);
+
+        JsonObject expectedRequestBody = new JsonObject();
+        expectedRequestBody.addProperty("owner", api.getOwner().getTypedID().toString());
+        expectedRequestBody.addProperty("gatewayThingID", gatewayThingID);
+        expectedRequestBody.addProperty("endNodeVendorThingID", vendorThingID);
+        expectedRequestBody.addProperty("endNodePassword", thingPassword);
+        expectedRequestBody.addProperty("endNodeThingType", DEMO_THING_TYPE);
+        expectedRequestBody.add("endNodeThingProperties", new JsonParser().parse(thingProperties.toString()));
+        expectedRequestBody.addProperty("dataGroupingInterval", "1_MINUTE");
+        this.assertRequestBody(expectedRequestBody, request);
+    }
+    @Test
+    public void onboardEndnodeWithGatewayOptions403ErrorTest() throws Exception {
+        String gatewayThingID = UUID.randomUUID().toString();
+        String gatewayVendorThingID = UUID.randomUUID().toString();
+        String vendorThingID = UUID.randomUUID().toString();
+        String thingPassword = "password";
+        JSONObject thingProperties = new JSONObject();
+        thingProperties.put("manufacturer", "Kii");
+        OnboardEndnodeWithGatewayOptions.Builder options = new OnboardEndnodeWithGatewayOptions.Builder();
+        options.setDataGroupingInterval(DataGroupingInterval.INTERVAL_30_MINUTES);
+        this.addEmptyMockResponse(403);
+
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        api.setTarget(new Gateway(gatewayThingID, gatewayVendorThingID));
+        try {
+            api.onboardEndnodeWithGateway(
+                    new PendingEndNode(vendorThingID, DEMO_THING_TYPE, thingProperties),
+                    thingPassword, options.build());
+            Assert.fail("ThingIFRestException should be thrown");
+        } catch (ForbiddenException e) {
+        }
+        // verify the request
+        RecordedRequest request = this.server.takeRequest(1, TimeUnit.SECONDS);
+        Assert.assertEquals(BASE_PATH + "/onboardings", request.getPath());
+        Assert.assertEquals("POST", request.getMethod());
+
+        Map<String, String> expectedRequestHeaders = new HashMap<String, String>();
+        expectedRequestHeaders.put("X-Kii-AppID", APP_ID);
+        expectedRequestHeaders.put("X-Kii-AppKey", APP_KEY);
+        expectedRequestHeaders.put("Authorization", "Bearer " + api.getOwner().getAccessToken());
+        expectedRequestHeaders.put("Content-Type", "application/vnd.kii.OnboardingEndNodeWithGatewayThingID+json");
+        this.assertRequestHeader(expectedRequestHeaders, request);
+
+        JsonObject expectedRequestBody = new JsonObject();
+        expectedRequestBody.addProperty("owner", api.getOwner().getTypedID().toString());
+        expectedRequestBody.addProperty("gatewayThingID", gatewayThingID);
+        expectedRequestBody.addProperty("endNodeVendorThingID", vendorThingID);
+        expectedRequestBody.addProperty("endNodePassword", thingPassword);
+        expectedRequestBody.addProperty("endNodeThingType", DEMO_THING_TYPE);
+        expectedRequestBody.add("endNodeThingProperties", new JsonParser().parse(thingProperties.toString()));
+        expectedRequestBody.addProperty("dataGroupingInterval", "30_MINUTES");
+        this.assertRequestBody(expectedRequestBody, request);
+    }
+    @Test
+    public void onboardEndnodeWithGatewayOptions404ErrorTest() throws Exception {
+        String gatewayThingID = UUID.randomUUID().toString();
+        String gatewayVendorThingID = UUID.randomUUID().toString();
+        String vendorThingID = UUID.randomUUID().toString();
+        String thingPassword = "password";
+        JSONObject thingProperties = new JSONObject();
+        thingProperties.put("manufacturer", "Kii");
+        OnboardEndnodeWithGatewayOptions.Builder options = new OnboardEndnodeWithGatewayOptions.Builder();
+        options.setDataGroupingInterval(DataGroupingInterval.INTERVAL_1_HOUR);
+        this.addEmptyMockResponse(404);
+
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        api.setTarget(new Gateway(gatewayThingID, gatewayVendorThingID));
+        try {
+            api.onboardEndnodeWithGateway(
+                    new PendingEndNode(vendorThingID, DEMO_THING_TYPE, thingProperties),
+                    thingPassword, options.build());
+            Assert.fail("ThingIFRestException should be thrown");
+        } catch (NotFoundException e) {
+        }
+        // verify the request
+        RecordedRequest request = this.server.takeRequest(1, TimeUnit.SECONDS);
+        Assert.assertEquals(BASE_PATH + "/onboardings", request.getPath());
+        Assert.assertEquals("POST", request.getMethod());
+
+        Map<String, String> expectedRequestHeaders = new HashMap<String, String>();
+        expectedRequestHeaders.put("X-Kii-AppID", APP_ID);
+        expectedRequestHeaders.put("X-Kii-AppKey", APP_KEY);
+        expectedRequestHeaders.put("Authorization", "Bearer " + api.getOwner().getAccessToken());
+        expectedRequestHeaders.put("Content-Type", "application/vnd.kii.OnboardingEndNodeWithGatewayThingID+json");
+        this.assertRequestHeader(expectedRequestHeaders, request);
+
+        JsonObject expectedRequestBody = new JsonObject();
+        expectedRequestBody.addProperty("owner", api.getOwner().getTypedID().toString());
+        expectedRequestBody.addProperty("gatewayThingID", gatewayThingID);
+        expectedRequestBody.addProperty("endNodeVendorThingID", vendorThingID);
+        expectedRequestBody.addProperty("endNodePassword", thingPassword);
+        expectedRequestBody.addProperty("endNodeThingType", DEMO_THING_TYPE);
+        expectedRequestBody.add("endNodeThingProperties", new JsonParser().parse(thingProperties.toString()));
+        expectedRequestBody.addProperty("dataGroupingInterval", "1_HOUR");
+        this.assertRequestBody(expectedRequestBody, request);
+    }
+    @Test
+    public void onboardEndnodeWithGatewayOptions500ErrorTest() throws Exception {
+        String gatewayThingID = UUID.randomUUID().toString();
+        String gatewayVendorThingID = UUID.randomUUID().toString();
+        String vendorThingID = UUID.randomUUID().toString();
+        String thingPassword = "password";
+        JSONObject thingProperties = new JSONObject();
+        thingProperties.put("manufacturer", "Kii");
+        OnboardEndnodeWithGatewayOptions.Builder options = new OnboardEndnodeWithGatewayOptions.Builder();
+        options.setDataGroupingInterval(DataGroupingInterval.INTERVAL_12_HOURS);
+        this.addEmptyMockResponse(500);
+
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        api.setTarget(new Gateway(gatewayThingID, gatewayVendorThingID));
+        try {
+            api.onboardEndnodeWithGateway(
+                    new PendingEndNode(vendorThingID, DEMO_THING_TYPE, thingProperties),
+                    thingPassword, options.build());
+            Assert.fail("ThingIFRestException should be thrown");
+        } catch (InternalServerErrorException e) {
+        }
+        // verify the request
+        RecordedRequest request = this.server.takeRequest(1, TimeUnit.SECONDS);
+        Assert.assertEquals(BASE_PATH + "/onboardings", request.getPath());
+        Assert.assertEquals("POST", request.getMethod());
+
+        Map<String, String> expectedRequestHeaders = new HashMap<String, String>();
+        expectedRequestHeaders.put("X-Kii-AppID", APP_ID);
+        expectedRequestHeaders.put("X-Kii-AppKey", APP_KEY);
+        expectedRequestHeaders.put("Authorization", "Bearer " + api.getOwner().getAccessToken());
+        expectedRequestHeaders.put("Content-Type", "application/vnd.kii.OnboardingEndNodeWithGatewayThingID+json");
+        this.assertRequestHeader(expectedRequestHeaders, request);
+
+        JsonObject expectedRequestBody = new JsonObject();
+        expectedRequestBody.addProperty("owner", api.getOwner().getTypedID().toString());
+        expectedRequestBody.addProperty("gatewayThingID", gatewayThingID);
+        expectedRequestBody.addProperty("endNodeVendorThingID", vendorThingID);
+        expectedRequestBody.addProperty("endNodePassword", thingPassword);
+        expectedRequestBody.addProperty("endNodeThingType", DEMO_THING_TYPE);
+        expectedRequestBody.add("endNodeThingProperties", new JsonParser().parse(thingProperties.toString()));
+        expectedRequestBody.addProperty("dataGroupingInterval", "12_HOURS");
+        this.assertRequestBody(expectedRequestBody, request);
+    }
+    @Test(expected = IllegalStateException.class)
+    public void onboardEndnodeWithGatewayOptionsWithoutOnboardingGatewayTest() throws Exception {
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        Target target = api.onboardEndnodeWithGateway(new PendingEndNode("v1234567890abcde", DEMO_THING_TYPE), "password", null);
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void onboardEndnodeWithGatewayOptionsWithNullVendorThingIDTest() throws Exception {
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        api.setTarget(new Gateway("gateway-thing-id", "gateway-vendor-thing-id"));
+        Target target = api.onboardEndnodeWithGateway(new PendingEndNode(null, DEMO_THING_TYPE, null), "password", null);
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void onboardEndnodeWithGatewayOptionsWithEmptyVendorThingIDTest() throws Exception {
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        api.setTarget(new Gateway("gateway-thing-id", "gateway-vendor-thing-id"));
+        Target target = api.onboardEndnodeWithGateway(new PendingEndNode("", DEMO_THING_TYPE, null), "password", null);
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void onboardEndnodeWithGatewayOptionsWithNullVendorThingPasswordTest() throws Exception {
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        api.setTarget(new Gateway("gateway-thing-id", "gateway-vendor-thing-id"));
+        Target target = api.onboardEndnodeWithGateway(new PendingEndNode("v1234567890abcde", DEMO_THING_TYPE, null), null, null);
+    }
+    @Test(expected = IllegalArgumentException.class)
+    public void onboardEndnodeWithGatewayOptionsWithEmptyVendorThingPasswordTest() throws Exception {
+        ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        api.setTarget(new Gateway("gateway-thing-id", "gateway-vendor-thing-id"));
+        Target target = api.onboardEndnodeWithGateway(new PendingEndNode("v1234567890abcde", DEMO_THING_TYPE, null), "", null);
+    }
 }


### PR DESCRIPTION
## Summary of background:
We add optional parameters to onboard API methods in #104.
This PR is small tests for #104 

## Tests
Small tests are done with:
 * [ThingIFAPI_OnBoardTest.java](https://github.com/KiiPlatform/thing-if-AndroidSDK/blob/onboard_with_options_small_tests/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_OnBoardTest.java)
 * [ThingIFAPI_OnboardEndnodeWithGatewayTest.java](https://github.com/KiiPlatform/thing-if-AndroidSDK/blob/onboard_with_options_small_tests/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_OnboardEndnodeWithGatewayTest.java)

## Reference
Issue: #98 
PR: #99, #104