### PR TITLE
change getTargetID in Trigger.

### DIFF
--- a/extras/TestAppForCrossTrigger/.idea/misc.xml
+++ b/extras/TestAppForCrossTrigger/.idea/misc.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="EntryPointsManager">
+    <entry_points version="2.0" />
+  </component>
   <component name="NullableNotNullManager">
     <option name="myDefaultNullable" value="android.support.annotation.Nullable" />
     <option name="myDefaultNotNull" value="android.support.annotation.NonNull" />

--- a/extras/TestAppForCrossTrigger/app/src/main/java/test/android/example/com/testappforcrosstrigger/MainActivity.java
+++ b/extras/TestAppForCrossTrigger/app/src/main/java/test/android/example/com/testappforcrosstrigger/MainActivity.java
@@ -75,7 +75,8 @@ public class MainActivity extends AppCompatActivity {
                     Log.d(this.getClass().getName(), "API target ID     : " + api.getTarget().getTypedID().getID());
                     Log.d(this.getClass().getName(), "Command target ID : " + commandTarget.getTypedID().getID());
                     Log.d(this.getClass().getName(), "Trigger target ID : " + response.getTargetID().getID());
-                    Log.d(this.getClass().getName(), "Trigger command ID: " + response.getCommand().getTargetID().getID());
+                    Log.d(this.getClass().getName(), "Trigger com tar ID: " + response.getCommand().getTargetID().getID());
+                    Log.d(this.getClass().getName(), "Trigger command ID: " + response.getCommand().getCommandID());
                 } else {
                     Log.d(this.getClass().getName(), "failed.");
                 }

--- a/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PostNewTriggerTest.java
+++ b/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PostNewTriggerTest.java
@@ -133,6 +133,7 @@ public class ThingIFAPI_PostNewTriggerTest extends ThingIFAPITestBase {
         Trigger trigger = api.postNewTrigger(DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate, commandTarget);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
+        Assert.assertEquals(target.getTypedID(), trigger.getTargetID());
         Assert.assertEquals(false, trigger.disabled());
         Assert.assertNull(trigger.getDisabledReason());
         Assert.assertNull(trigger.getServerCode());

--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -974,7 +974,9 @@ public class ThingIFAPI implements Parcelable {
                 throw new UnsupportedSchemaException(schemaName, schemaVersion);
             }
         }
-        return this.deserialize(schema, responseBody, Trigger.class);
+        Trigger retval = this.deserialize(schema, responseBody, Trigger.class);
+        retval.setTargetID(this.target.getTypedID());
+        return retval;
     }
 
     /**
@@ -1242,7 +1244,9 @@ public class ThingIFAPI implements Parcelable {
                         continue;
                     }
                 }
-                triggers.add(this.deserialize(schema, triggerJson, Trigger.class));
+                Trigger trigger = this.deserialize(schema, triggerJson, Trigger.class);
+                trigger.setTargetID(this.target.getTypedID());
+                triggers.add(trigger);
             }
         }
         return new Pair<List<Trigger>, String>(triggers, nextPaginationKey);

--- a/thingif/src/main/java/com/kii/thingif/trigger/Trigger.java
+++ b/thingif/src/main/java/com/kii/thingif/trigger/Trigger.java
@@ -17,6 +17,7 @@ import org.json.JSONObject;
 public class Trigger implements Parcelable {
 
     private String triggerID;
+    private TypedID targetID;
     private final Predicate predicate;
     private final Command command;
     private final ServerCode serverCode;
@@ -56,11 +57,9 @@ public class Trigger implements Parcelable {
         this.triggerID = triggerID;
     }
     public TypedID getTargetID() {
-        if (this.command == null) {
-            return null;
-        }
-        return this.command.getTargetID();
+        return this.targetID;
     }
+    public void setTargetID(TypedID targetID) { this.targetID = targetID; }
 
     public boolean disabled() {
         return this.disabled;
@@ -143,6 +142,7 @@ public class Trigger implements Parcelable {
     // Implementation of Parcelable
     protected Trigger(Parcel in) {
         this.triggerID = in.readString();
+        this.targetID = in.readParcelable(TypedID.class.getClassLoader());
         this.predicate = in.readParcelable(Predicate.class.getClassLoader());
         this.command = in.readParcelable(Command.class.getClassLoader());
         this.serverCode = in.readParcelable(Command.class.getClassLoader());
@@ -180,6 +180,7 @@ public class Trigger implements Parcelable {
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeString(this.triggerID);
+        dest.writeParcelable(this.targetID, flags);
         dest.writeParcelable(this.predicate, flags);
         dest.writeParcelable(this.command, flags);
         dest.writeParcelable(this.serverCode, flags);


### PR DESCRIPTION
クロストリガーに関連して、Trigger#getTargetID()が関連するThingIFAPIのターゲットIDを返すように修正しました。

TriggerのsetTargetIDをpublicで追加しましたが、Triggerの持つターゲットIDがSDK外への告知用(内部では使用していない)なのでpublicにして書き換えられても問題がないと判断しpublicにしました。
これをpackage internalなどにするとTriggerやその関連クラスのパッケージを変更する必要があり、大事になるので上記の判断をしています。

Issue: #110 
