### PR TITLE
change getTargetID in Trigger.

### DIFF
--- a/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PostNewTriggerTest.java
+++ b/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PostNewTriggerTest.java
@@ -133,6 +133,7 @@ public class ThingIFAPI_PostNewTriggerTest extends ThingIFAPITestBase {
         Trigger trigger = api.postNewTrigger(DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions, predicate, commandTarget);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
+        Assert.assertEquals(target.getTypedID(), trigger.getTargetID());
         Assert.assertEquals(false, trigger.disabled());
         Assert.assertNull(trigger.getDisabledReason());
         Assert.assertNull(trigger.getServerCode());

--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -1425,12 +1425,14 @@ public class ThingIFAPI implements Parcelable {
         return this.deserialize(schema, json.toString(), clazz);
     }
     private Trigger deserialize(Schema schema, JSONObject json, TypedID targetID) throws ThingIFException {
+        JSONObject copied = null;
         try {
-            json.put("targetID", targetID.toString());
+            copied = new JSONObject(json.toString());
+            copied.put("targetID", targetID.toString());
         } catch (JSONException e) {
             throw new ThingIFException("unexpected error.", e);
         }
-        return this.deserialize(schema, json.toString(), Trigger.class);
+        return this.deserialize(schema, copied.toString(), Trigger.class);
     }
     private <T> T deserialize(Schema schema, String json, Class<T> clazz) throws ThingIFException {
         try {

--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -974,7 +974,9 @@ public class ThingIFAPI implements Parcelable {
                 throw new UnsupportedSchemaException(schemaName, schemaVersion);
             }
         }
-        return this.deserialize(schema, responseBody, Trigger.class);
+        Trigger retval = this.deserialize(schema, responseBody, Trigger.class);
+        retval.setTargetID(this.target.getTypedID());
+        return retval;
     }
 
     /**
@@ -1242,7 +1244,9 @@ public class ThingIFAPI implements Parcelable {
                         continue;
                     }
                 }
-                triggers.add(this.deserialize(schema, triggerJson, Trigger.class));
+                Trigger trigger = this.deserialize(schema, triggerJson, Trigger.class);
+                trigger.setTargetID(this.target.getTypedID());
+                triggers.add(trigger);
             }
         }
         return new Pair<List<Trigger>, String>(triggers, nextPaginationKey);

--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -974,7 +974,7 @@ public class ThingIFAPI implements Parcelable {
                 throw new UnsupportedSchemaException(schemaName, schemaVersion);
             }
         }
-        return this.deserialize(schema, responseBody, this.target.getTypedID(), Trigger.class);
+        return this.deserialize(schema, responseBody, this.target.getTypedID());
     }
 
     /**
@@ -1242,8 +1242,7 @@ public class ThingIFAPI implements Parcelable {
                         continue;
                     }
                 }
-                triggers.add(this.deserialize(schema, triggerJson, this.target.getTypedID(),
-                        Trigger.class));
+                triggers.add(this.deserialize(schema, triggerJson, this.target.getTypedID()));
             }
         }
         return new Pair<List<Trigger>, String>(triggers, nextPaginationKey);
@@ -1425,13 +1424,13 @@ public class ThingIFAPI implements Parcelable {
     private <T> T deserialize(Schema schema, JSONObject json, Class<T> clazz) throws ThingIFException {
         return this.deserialize(schema, json.toString(), clazz);
     }
-    private <T> T deserialize(Schema schema, JSONObject json, TypedID targetID, Class<T> clazz) throws ThingIFException {
+    private Trigger deserialize(Schema schema, JSONObject json, TypedID targetID) throws ThingIFException {
         try {
             json.put("targetID", targetID.toString());
         } catch (JSONException e) {
             throw new ThingIFException("unexpected error.", e);
         }
-        return this.deserialize(schema, json.toString(), clazz);
+        return this.deserialize(schema, json.toString(), Trigger.class);
     }
     private <T> T deserialize(Schema schema, String json, Class<T> clazz) throws ThingIFException {
         try {

--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -974,9 +974,7 @@ public class ThingIFAPI implements Parcelable {
                 throw new UnsupportedSchemaException(schemaName, schemaVersion);
             }
         }
-        Trigger retval = this.deserialize(schema, responseBody, Trigger.class);
-        retval.setTargetID(this.target.getTypedID());
-        return retval;
+        return this.deserialize(schema, responseBody, this.target.getTypedID(), Trigger.class);
     }
 
     /**
@@ -1244,9 +1242,8 @@ public class ThingIFAPI implements Parcelable {
                         continue;
                     }
                 }
-                Trigger trigger = this.deserialize(schema, triggerJson, Trigger.class);
-                trigger.setTargetID(this.target.getTypedID());
-                triggers.add(trigger);
+                triggers.add(this.deserialize(schema, triggerJson, this.target.getTypedID(),
+                        Trigger.class));
             }
         }
         return new Pair<List<Trigger>, String>(triggers, nextPaginationKey);
@@ -1426,6 +1423,14 @@ public class ThingIFAPI implements Parcelable {
         return this.deserialize(null, json, clazz);
     }
     private <T> T deserialize(Schema schema, JSONObject json, Class<T> clazz) throws ThingIFException {
+        return this.deserialize(schema, json.toString(), clazz);
+    }
+    private <T> T deserialize(Schema schema, JSONObject json, TypedID targetID, Class<T> clazz) throws ThingIFException {
+        try {
+            json.put("targetID", targetID.toString());
+        } catch (JSONException e) {
+            throw new ThingIFException("unexpected error.", e);
+        }
         return this.deserialize(schema, json.toString(), clazz);
     }
     private <T> T deserialize(Schema schema, String json, Class<T> clazz) throws ThingIFException {

--- a/thingif/src/main/java/com/kii/thingif/trigger/Trigger.java
+++ b/thingif/src/main/java/com/kii/thingif/trigger/Trigger.java
@@ -17,6 +17,7 @@ import org.json.JSONObject;
 public class Trigger implements Parcelable {
 
     private String triggerID;
+    private TypedID targetID;
     private final Predicate predicate;
     private final Command command;
     private final ServerCode serverCode;
@@ -56,11 +57,9 @@ public class Trigger implements Parcelable {
         this.triggerID = triggerID;
     }
     public TypedID getTargetID() {
-        if (this.command == null) {
-            return null;
-        }
-        return this.command.getTargetID();
+        return this.targetID;
     }
+    public void setTargetID(TypedID targetID) { this.targetID = targetID; }
 
     public boolean disabled() {
         return this.disabled;
@@ -143,6 +142,7 @@ public class Trigger implements Parcelable {
     // Implementation of Parcelable
     protected Trigger(Parcel in) {
         this.triggerID = in.readString();
+        this.targetID = in.readParcelable(TypedID.class.getClassLoader());
         this.predicate = in.readParcelable(Predicate.class.getClassLoader());
         this.command = in.readParcelable(Command.class.getClassLoader());
         this.serverCode = in.readParcelable(Command.class.getClassLoader());
@@ -180,6 +180,7 @@ public class Trigger implements Parcelable {
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeString(this.triggerID);
+        dest.writeParcelable(this.targetID, flags);
         dest.writeParcelable(this.predicate, flags);
         dest.writeParcelable(this.command, flags);
         dest.writeParcelable(this.serverCode, flags);

--- a/thingif/src/main/java/com/kii/thingif/trigger/Trigger.java
+++ b/thingif/src/main/java/com/kii/thingif/trigger/Trigger.java
@@ -59,7 +59,6 @@ public class Trigger implements Parcelable {
     public TypedID getTargetID() {
         return this.targetID;
     }
-    public void setTargetID(TypedID targetID) { this.targetID = targetID; }
 
     public boolean disabled() {
         return this.disabled;


### PR DESCRIPTION
クロストリガーに関連して、Trigger#getTargetID()が関連するThingIFAPIのターゲットIDを返すように修正しました。

TriggerのsetTargetIDをpublicで追加しましたが、Triggerの持つターゲットIDがSDK外への告知用(内部では使用していない)なのでpublicにして書き換えられても問題がないと判断しpublicにしました。
これをpackage internalなどにするとTriggerやその関連クラスのパッケージを変更する必要があり、大事になるので上記の判断をしています。

Issue: #110
