### PR TITLE
Rename builder

### DIFF
--- a/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PatchTriggerTest.java
+++ b/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PatchTriggerTest.java
@@ -126,7 +126,7 @@ public class ThingIFAPI_PatchTriggerTest extends ThingIFAPITestBase {
         JSONObject metadata = new JSONObject();
         metadata.put("key", "value");
         TriggerOptions options =
-            TriggerOptions.Builder.builder().setTitle("title").
+            TriggerOptions.Builder.newBuilder().setTitle("title").
                 setDescription("description").setMetadata(metadata).build();
         Command expectedCommand = new Command(schema.getSchemaName(),
                 schema.getSchemaVersion(),

--- a/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PatchTriggerTest.java
+++ b/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PatchTriggerTest.java
@@ -139,7 +139,7 @@ public class ThingIFAPI_PatchTriggerTest extends ThingIFAPITestBase {
                         "vendor-thing-id", accessToken));
         Trigger trigger = api.patchTrigger(
             triggerID,
-            TriggeredCommandForm.Builder.builder(
+            TriggeredCommandForm.Builder.newBuilder(
                 DEMO_SCHEMA_NAME,
                 DEMO_SCHEMA_VERSION,
                 actions).setTargetID(thingID2).build(),
@@ -501,7 +501,7 @@ public class ThingIFAPI_PatchTriggerTest extends ThingIFAPITestBase {
                             "vendor-thing-id", accessToken));
             api.patchTrigger(
                 triggerID,
-                TriggeredCommandForm.Builder.builder(
+                TriggeredCommandForm.Builder.newBuilder(
                     DEMO_SCHEMA_NAME,
                     DEMO_SCHEMA_VERSION,
                     actions).setTargetID(thingID2).build(),
@@ -562,7 +562,7 @@ public class ThingIFAPI_PatchTriggerTest extends ThingIFAPITestBase {
                             "vendor-thing-id", accessToken));
             api.patchTrigger(
                 triggerID,
-                TriggeredCommandForm.Builder.builder(
+                TriggeredCommandForm.Builder.newBuilder(
                     DEMO_SCHEMA_NAME,
                     DEMO_SCHEMA_VERSION,
                     actions).setTargetID(thingID2).build(),
@@ -622,7 +622,7 @@ public class ThingIFAPI_PatchTriggerTest extends ThingIFAPITestBase {
                             "vendor-thing-id", accessToken));
             api.patchTrigger(
                 triggerID,
-                TriggeredCommandForm.Builder.builder(
+                TriggeredCommandForm.Builder.newBuilder(
                     DEMO_SCHEMA_NAME,
                     DEMO_SCHEMA_VERSION,
                     actions).setTargetID(thingID2).build(),
@@ -681,7 +681,7 @@ public class ThingIFAPI_PatchTriggerTest extends ThingIFAPITestBase {
                         "vendor-thing-id", accessToken));
         api.patchTrigger(
             null,
-            TriggeredCommandForm.Builder.builder(
+            TriggeredCommandForm.Builder.newBuilder(
                 DEMO_SCHEMA_NAME,
                 DEMO_SCHEMA_VERSION,
                 actions).setTargetID(thingID2).build(),
@@ -709,7 +709,7 @@ public class ThingIFAPI_PatchTriggerTest extends ThingIFAPITestBase {
                         "vendor-thing-id", accessToken));
         api.patchTrigger(
             "",
-            TriggeredCommandForm.Builder.builder(
+            TriggeredCommandForm.Builder.newBuilder(
                 DEMO_SCHEMA_NAME,
                 DEMO_SCHEMA_VERSION,
                 actions).setTargetID(thingID2).build(),

--- a/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PostNewTriggerForSchedulePredicateTest.java
+++ b/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PostNewTriggerForSchedulePredicateTest.java
@@ -419,7 +419,7 @@ public class ThingIFAPI_PostNewTriggerForSchedulePredicateTest
 
         JSONObject metadata = new JSONObject();
         metadata.put("key", "value");
-        TriggerOptions options = TriggerOptions.Builder.builder().
+        TriggerOptions options = TriggerOptions.Builder.newBuilder().
                 setTitle("title").setDescription("description").
                 setMetadata(metadata).build();
         Command expectedCommand = new Command(

--- a/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PostNewTriggerForSchedulePredicateTest.java
+++ b/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PostNewTriggerForSchedulePredicateTest.java
@@ -441,7 +441,7 @@ public class ThingIFAPI_PostNewTriggerForSchedulePredicateTest
 
         ThingIFAPIUtils.setTarget(api, target);
         Trigger trigger = api.postNewTrigger(
-                TriggeredCommandForm.Builder.builder(
+                TriggeredCommandForm.Builder.newBuilder(
                     DEMO_SCHEMA_NAME,
                     DEMO_SCHEMA_VERSION,
                     actions).setTargetID(thingIDB).build(),
@@ -530,7 +530,7 @@ public class ThingIFAPI_PostNewTriggerForSchedulePredicateTest
         try {
             ThingIFAPIUtils.setTarget(api, target);
             api.postNewTrigger(
-                TriggeredCommandForm.Builder.builder(
+                TriggeredCommandForm.Builder.newBuilder(
                     DEMO_SCHEMA_NAME,
                     DEMO_SCHEMA_VERSION,
                     actions).setTargetID(thingIDB).build(),
@@ -581,7 +581,7 @@ public class ThingIFAPI_PostNewTriggerForSchedulePredicateTest
         try {
             ThingIFAPIUtils.setTarget(api, target);
             api.postNewTrigger(
-                TriggeredCommandForm.Builder.builder(
+                TriggeredCommandForm.Builder.newBuilder(
                     DEMO_SCHEMA_NAME,
                     DEMO_SCHEMA_VERSION,
                     actions).setTargetID(thingIDB).build(),
@@ -632,7 +632,7 @@ public class ThingIFAPI_PostNewTriggerForSchedulePredicateTest
         try {
             ThingIFAPIUtils.setTarget(api, target);
             api.postNewTrigger(
-                TriggeredCommandForm.Builder.builder(
+                TriggeredCommandForm.Builder.newBuilder(
                     DEMO_SCHEMA_NAME,
                     DEMO_SCHEMA_VERSION,
                     actions).setTargetID(thingIDB).build(),
@@ -693,7 +693,7 @@ public class ThingIFAPI_PostNewTriggerForSchedulePredicateTest
         ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
         ThingIFAPIUtils.setTarget(api, target);
         api.postNewTrigger(
-            TriggeredCommandForm.Builder.builder(
+            TriggeredCommandForm.Builder.newBuilder(
                 DEMO_SCHEMA_NAME, DEMO_SCHEMA_VERSION, actions).build(),
             null, null);
     }

--- a/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PostNewTriggerTest.java
+++ b/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PostNewTriggerTest.java
@@ -132,7 +132,7 @@ public class ThingIFAPI_PostNewTriggerTest extends ThingIFAPITestBase {
 
         ThingIFAPIUtils.setTarget(api, target);
         Trigger trigger = api.postNewTrigger(
-            TriggeredCommandForm.Builder.builder(
+            TriggeredCommandForm.Builder.newBuilder(
                 DEMO_SCHEMA_NAME,
                 DEMO_SCHEMA_VERSION,
                 actions).setTargetID(thingIDB).build(),
@@ -498,7 +498,7 @@ public class ThingIFAPI_PostNewTriggerTest extends ThingIFAPITestBase {
         try {
             ThingIFAPIUtils.setTarget(api, target);
             api.postNewTrigger(
-                TriggeredCommandForm.Builder.builder(
+                TriggeredCommandForm.Builder.newBuilder(
                     DEMO_SCHEMA_NAME,
                     DEMO_SCHEMA_VERSION,
                     actions).setTargetID(thingIDB).build(),
@@ -548,7 +548,7 @@ public class ThingIFAPI_PostNewTriggerTest extends ThingIFAPITestBase {
         try {
             ThingIFAPIUtils.setTarget(api, target);
             api.postNewTrigger(
-                TriggeredCommandForm.Builder.builder(
+                TriggeredCommandForm.Builder.newBuilder(
                     DEMO_SCHEMA_NAME,
                     DEMO_SCHEMA_VERSION,
                     actions).setTargetID(thingIDB).build(),
@@ -598,7 +598,7 @@ public class ThingIFAPI_PostNewTriggerTest extends ThingIFAPITestBase {
         try {
             ThingIFAPIUtils.setTarget(api, target);
             api.postNewTrigger(
-                TriggeredCommandForm.Builder.builder(
+                TriggeredCommandForm.Builder.newBuilder(
                     DEMO_SCHEMA_NAME,
                     DEMO_SCHEMA_VERSION,
                     actions).setTargetID(thingIDB).build(),
@@ -654,7 +654,7 @@ public class ThingIFAPI_PostNewTriggerTest extends ThingIFAPITestBase {
         ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
         ThingIFAPIUtils.setTarget(api, target);
         api.postNewTrigger(
-            TriggeredCommandForm.Builder.builder(
+            TriggeredCommandForm.Builder.newBuilder(
                 DEMO_SCHEMA_NAME,
                 DEMO_SCHEMA_VERSION,
                 actions).build(),

--- a/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PostNewTriggerTest.java
+++ b/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PostNewTriggerTest.java
@@ -202,7 +202,7 @@ public class ThingIFAPI_PostNewTriggerTest extends ThingIFAPITestBase {
         JSONObject metadata = new JSONObject();
         metadata.put("key", "value");
         this.postNewTriggerWithFormAndOptionTest(predicate,
-                TriggerOptions.Builder.builder().setTitle("title").
+                TriggerOptions.Builder.newBuilder().setTitle("title").
                 setDescription("description").setMetadata(metadata).build());
     }
 
@@ -637,7 +637,7 @@ public class ThingIFAPI_PostNewTriggerTest extends ThingIFAPITestBase {
         ThingIFAPIUtils.setTarget(api, target);
         api.postNewTrigger(null,
                 predicate,
-                TriggerOptions.Builder.builder().setTitle("title").build());
+                TriggerOptions.Builder.newBuilder().setTitle("title").build());
     }
     @Test(expected = IllegalArgumentException.class)
     public void postNewTriggerWithTargetAndNullPredicateTest() throws Exception {
@@ -659,6 +659,6 @@ public class ThingIFAPI_PostNewTriggerTest extends ThingIFAPITestBase {
                 DEMO_SCHEMA_VERSION,
                 actions).build(),
             null,
-            TriggerOptions.Builder.builder().setTitle("title").build());
+            TriggerOptions.Builder.newBuilder().setTitle("title").build());
     }
 }

--- a/thingif/src/androidTest/java/com/kii/thingif/trigger/TriggerOptionsTest.java
+++ b/thingif/src/androidTest/java/com/kii/thingif/trigger/TriggerOptionsTest.java
@@ -96,7 +96,7 @@ public class TriggerOptionsTest extends SmallTestBase {
             TestData input = test.input;
             TestData expected = test.expected;
             String errorMessage = test.errorMessage;
-            TriggerOptions.Builder builder = TriggerOptions.Builder.builder();
+            TriggerOptions.Builder builder = TriggerOptions.Builder.newBuilder();
 
             if (input.title != null) {
                 Assert.assertEquals(errorMessage,
@@ -162,7 +162,7 @@ public class TriggerOptionsTest extends SmallTestBase {
             TestData input = test.input;
             String expected = test.expected;
             String errorMessage = test.errorMessage;
-            TriggerOptions.Builder builder = TriggerOptions.Builder.builder();
+            TriggerOptions.Builder builder = TriggerOptions.Builder.newBuilder();
             IllegalArgumentException actual = null;
 
             try {
@@ -186,7 +186,7 @@ public class TriggerOptionsTest extends SmallTestBase {
         JSONObject metadata1 = new JSONObject();
         metadata1.put("key1", "value1");
 
-        TriggerOptions.Builder builder = TriggerOptions.Builder.builder();
+        TriggerOptions.Builder builder = TriggerOptions.Builder.newBuilder();
 
         builder.setTitle(title1).setDescription(description1).
                 setMetadata(metadata1);

--- a/thingif/src/androidTest/java/com/kii/thingif/trigger/TriggeredCommandFormTest.java
+++ b/thingif/src/androidTest/java/com/kii/thingif/trigger/TriggeredCommandFormTest.java
@@ -261,7 +261,7 @@ public class TriggeredCommandFormTest extends SmallTestBase {
             TestData data = testCase.input;
             TestData expected = testCase.expected;
             TriggeredCommandForm.Builder builder =
-                    TriggeredCommandForm.Builder.builder(
+                    TriggeredCommandForm.Builder.newBuilder(
                         data.schemaName,
                         data.schemaVersion,
                         data.actions);
@@ -354,7 +354,7 @@ public class TriggeredCommandFormTest extends SmallTestBase {
             TestData data = testCase.input;
             TestData expected = testCase.expected;
             TriggeredCommandForm.Builder builder =
-                    TriggeredCommandForm.Builder.builder(
+                    TriggeredCommandForm.Builder.newBuilderFromCommand(
                         createCommand(data, defaultTarget));
 
             TypedID expectedTargetID = data.targetID != null ?
@@ -414,7 +414,7 @@ public class TriggeredCommandFormTest extends SmallTestBase {
             String expected = testCase.expected;
             IllegalArgumentException actual = null;
             try {
-                TriggeredCommandForm.Builder.builder(
+                TriggeredCommandForm.Builder.newBuilder(
                     input.schemaName,
                     input.schemaVersion,
                     input.actions);
@@ -462,7 +462,7 @@ public class TriggeredCommandFormTest extends SmallTestBase {
             IllegalArgumentException actual = null;
 
             TriggeredCommandForm.Builder builder =
-                    TriggeredCommandForm.Builder.builder(
+                    TriggeredCommandForm.Builder.newBuilder(
                         input.schemaName,
                         input.schemaVersion,
                         input.actions);
@@ -491,7 +491,7 @@ public class TriggeredCommandFormTest extends SmallTestBase {
         actions1.add(new SetColor(128, 0, 255));
 
         TriggeredCommandForm.Builder builder =
-                TriggeredCommandForm.Builder.builder(
+                TriggeredCommandForm.Builder.newBuilder(
                     schemaName1, schemaVersion1, actions1);
         Assert.assertEquals(schemaName1, builder.getSchemaName());
         Assert.assertEquals(schemaVersion1, builder.getSchemaVersion());

--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -795,7 +795,7 @@ public class ThingIFAPI implements Parcelable {
      * </p>
      * <code>
      * api.postNewTrigger(
-     *         TriggeredCommandForm.Builder.builder(
+     *         TriggeredCommandForm.Builder.newBuilder(
      *             schemaName,
      *             schemaVersion,
      *             actions).setTargetID(api.getTarget()).build(),
@@ -822,7 +822,7 @@ public class ThingIFAPI implements Parcelable {
             throws ThingIFException
     {
         return postNewTriggerWithForm(
-            TriggeredCommandForm.Builder.builder(
+            TriggeredCommandForm.Builder.newBuilder(
                 schemaName,
                 schemaVersion,
                 actions).build(),
@@ -1063,7 +1063,7 @@ public class ThingIFAPI implements Parcelable {
         }
         TriggeredCommandForm form = null;
         if (actions != null && actions.size() > 0) {
-            form = TriggeredCommandForm.Builder.builder(
+            form = TriggeredCommandForm.Builder.newBuilder(
                 schemaName, schemaVersion, actions).build();
         }
         return patchTriggerWithForm(triggerID, form, predicate, null);

--- a/thingif/src/main/java/com/kii/thingif/trigger/TriggerOptions.java
+++ b/thingif/src/main/java/com/kii/thingif/trigger/TriggerOptions.java
@@ -32,7 +32,7 @@ public class TriggerOptions implements Parcelable {
          * @return builder instance.
          */
         @NonNull
-        public static Builder builder() {
+        public static Builder newBuilder() {
             return new Builder();
         }
 

--- a/thingif/src/main/java/com/kii/thingif/trigger/TriggerOptions.java
+++ b/thingif/src/main/java/com/kii/thingif/trigger/TriggerOptions.java
@@ -37,37 +37,6 @@ public class TriggerOptions implements Parcelable {
         }
 
         /**
-         * Constructs a {@link TriggerOptions.Builder} instance.
-         *
-         * <p>
-         * This constructor copies followings {@link Trigger} fields:
-         * </p>
-         *
-         * <ul>
-         * <li>{@link Trigger#getTitle()}</li>
-         * <li>{@link Trigger#getDescription()}</li>
-         * <li>{@link Trigger#getMetadata()}</li>
-         * </ul>
-         *
-         * @param trigger source of this {@link TriggerOptions.Builder}
-         * instance.
-         * @return builder instance
-         * @throws IllegalArgumentException if trigger is null.
-         */
-        @NonNull
-        public static Builder newBuilderFromTrigger(
-                @NonNull Trigger trigger)
-            throws IllegalArgumentException
-        {
-            if (trigger == null) {
-                throw new IllegalArgumentException("trigger is null.");
-            }
-            return new Builder().setTitle(trigger.getTitle()).
-                    setDescription(trigger.getDescription()).
-                    setMetadata(trigger.getMetadata());
-        }
-
-        /**
          * Setter of title
          *
          * @param title Length of title must be equal or less than 50

--- a/thingif/src/main/java/com/kii/thingif/trigger/TriggerOptions.java
+++ b/thingif/src/main/java/com/kii/thingif/trigger/TriggerOptions.java
@@ -55,7 +55,7 @@ public class TriggerOptions implements Parcelable {
          * @throws IllegalArgumentException if trigger is null.
          */
         @NonNull
-        public static Builder builder(
+        public static Builder newBuilderFromTrigger(
                 @NonNull Trigger trigger)
             throws IllegalArgumentException
         {

--- a/thingif/src/main/java/com/kii/thingif/trigger/TriggeredCommandForm.java
+++ b/thingif/src/main/java/com/kii/thingif/trigger/TriggeredCommandForm.java
@@ -86,7 +86,7 @@ public class TriggeredCommandForm implements Parcelable {
          * @return builder instance.
          */
         @NonNull
-        public static Builder builder(
+        public static Builder newBuilder(
                 @NonNull String schemaName,
                 int schemaVersion,
                 @NonNull List<Action> actions)
@@ -118,7 +118,7 @@ public class TriggeredCommandForm implements Parcelable {
          * @throws IllegalArgumentException if command is null.
          */
         @NonNull
-        public static Builder builder(
+        public static Builder newBuilderFromCommand(
                 @NonNull Command command)
             throws IllegalArgumentException
         {


### PR DESCRIPTION
https://github.com/KiiPlatform/thing-if-AndroidSDK/pull/119#issuecomment-251277565

上記のコメントに従い、builderメソッドの名前を修正しました。修正内容は

  * `TriggeredCommandForm.Builder`
    * `builder(String, String, List<Action>)` -> `newBuilder(String, String, List<Action>)`
    * `builder(Command)` -> `newBuilderFromCommand(Command)`
  * `TriggerOptions.Builder`
    * `builder()` -> `newBuilder()`
    * `builder(Trigger)` -> `newBuilderFromTrigger(Trigger)`

となります。

Related issue: #119 
