### PR TITLE
new postNewTrigger and patchTrigger for server code

### DIFF
--- a/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPITestBase.java
+++ b/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPITestBase.java
@@ -200,9 +200,35 @@ public abstract class ThingIFAPITestBase extends SmallTestBase {
         this.server.enqueue(response);
     }
     protected void addMockResponseForGetTriggerWithServerCode(int httpStatus, String triggerID, ServerCode serverCode, Predicate predicate, Boolean disabled, String disabledReason, Schema schema) {
+        addMockResponseForGetTriggerWithServerCode(
+            httpStatus,
+            triggerID,
+            serverCode,
+            predicate,
+            null,
+            disabled,
+            disabledReason,
+            schema);
+    }
+
+    protected void addMockResponseForGetTriggerWithServerCode(
+            int httpStatus,
+            String triggerID,
+            ServerCode serverCode,
+            Predicate predicate,
+            TriggerOptions options,
+            Boolean disabled,
+            String disabledReason,
+            Schema schema)
+    {
         MockResponse response = new MockResponse().setResponseCode(httpStatus);
         if (httpStatus == 200) {
-            JsonObject responseBody = new JsonObject();
+            JsonObject responseBody = null;
+            if (options != null) {
+                responseBody = GsonRepository.gson().toJsonTree(options).getAsJsonObject();
+            } else {
+                responseBody = new JsonObject();
+            }
             if (triggerID != null) {
                 responseBody.addProperty("triggerID", triggerID);
             }

--- a/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PatchTriggerTest.java
+++ b/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PatchTriggerTest.java
@@ -435,7 +435,7 @@ public class ThingIFAPI_PatchTriggerTest extends ThingIFAPITestBase {
             actual = e;
         }
         Assert.assertNotNull(actual);
-        Assert.assertEquals(actual.getMessage(), "triggerID is null or empty.");
+        Assert.assertEquals(actual.getMessage(), "triggerID is null or empty");
     }
 
     @Test

--- a/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PatchTriggerTest.java
+++ b/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PatchTriggerTest.java
@@ -657,7 +657,8 @@ public class ThingIFAPI_PatchTriggerTest extends ThingIFAPITestBase {
     @Test(expected = IllegalStateException.class)
     public void patchTriggerWithNullArgumentsTest() throws Exception {
         ThingIFAPI api = createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
-        api.patchTrigger("trigger-1234", null, null, null);
+        api.patchTrigger("trigger-1234", (TriggeredCommandForm)null, null,
+                null);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PatchTriggerTest.java
+++ b/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PatchTriggerTest.java
@@ -250,6 +250,244 @@ public class ThingIFAPI_PatchTriggerTest extends ThingIFAPITestBase {
         ScheduleOncePredicate predicate = new ScheduleOncePredicate(1000);
         patchTriggerWithServerCodeTest(predicate);
     }
+
+    private void patchTriggerWithServerCodeAndOptionsTest(
+            Predicate predicate,
+            boolean sendServerCode,
+            boolean sendPredicate,
+            boolean sendOptions)
+        throws Exception
+    {
+        Schema schema = createDefaultSchema();
+        TypedID thingID = new TypedID(TypedID.Types.THING, "th.1234567890");
+        String accessToken = "thing-access-token-1234";
+        String triggerID = "trigger-1234";
+        Target target = new StandaloneThing(thingID.getID(), "vendor-thing-id",
+                accessToken);
+        ThingIFAPI api = createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+
+        TriggerOptions expectedOptions = TriggerOptions.Builder.newBuilder().
+                setTitle("title").
+                setDescription("description").
+                setMetadata(new JSONObject("{\"key\":\"value\"}")).build();
+        ServerCode expectedServerCode = new ServerCode(
+            "function_name", "token12345", "app0001",
+            new JSONObject("{\"param\":\"p0001\"}"));
+        addEmptyMockResponse(204);
+        addMockResponseForGetTriggerWithServerCode(200, triggerID,
+                expectedServerCode, predicate, expectedOptions, false, null,
+                schema);
+
+        ThingIFAPIUtils.setTarget(api, target);
+        Trigger trigger = api.patchTrigger(
+                triggerID,
+                sendServerCode ? expectedServerCode : null,
+                sendPredicate ? predicate : null,
+                sendOptions ? expectedOptions : null);
+        // verify the result
+        Assert.assertEquals(triggerID, trigger.getTriggerID());
+        Assert.assertEquals(false, trigger.disabled());
+        Assert.assertNull(trigger.getDisabledReason());
+        Assert.assertNull(trigger.getCommand());
+        assertPredicate(predicate, trigger.getPredicate());
+        assertServerCode(expectedServerCode, trigger.getServerCode());
+        assertTriggerOptions(expectedOptions, trigger);
+        // verify the 1st request
+        RecordedRequest request1 = this.server.takeRequest(1, TimeUnit.SECONDS);
+        Assert.assertEquals(BASE_PATH + "/targets/" + thingID.toString() +
+                "/triggers/" + triggerID, request1.getPath());
+        Assert.assertEquals("PATCH", request1.getMethod());
+
+        Map<String, String> expectedRequestHeaders1 = new HashMap<>();
+        expectedRequestHeaders1.put("X-Kii-AppID", APP_ID);
+        expectedRequestHeaders1.put("X-Kii-AppKey", APP_KEY);
+        expectedRequestHeaders1.put("Authorization",
+                "Bearer " + api.getOwner().getAccessToken());
+        expectedRequestHeaders1.put("Content-Type", "application/json");
+        assertRequestHeader(expectedRequestHeaders1, request1);
+
+        JsonObject expectedRequestBody = null;
+        if (sendOptions) {
+            expectedRequestBody =
+                GsonRepository.gson().toJsonTree(expectedOptions).getAsJsonObject();
+        } else {
+            expectedRequestBody = new JsonObject();
+        }
+        if (sendServerCode) {
+            expectedRequestBody.add("serverCode",
+                    GsonRepository.gson().toJsonTree(expectedServerCode));
+        }
+        if (sendPredicate) {
+            expectedRequestBody.add("predicate",
+                    GsonRepository.gson().toJsonTree(predicate));
+        }
+        expectedRequestBody.add("triggersWhat",
+                new JsonPrimitive("SERVER_CODE"));
+        this.assertRequestBody(expectedRequestBody, request1);
+
+        // verify the 2nd request
+        RecordedRequest request2 = this.server.takeRequest(1, TimeUnit.SECONDS);
+        Assert.assertEquals(BASE_PATH + "/targets/" + thingID.toString() +
+                "/triggers/" + triggerID, request2.getPath());
+        Assert.assertEquals("GET", request2.getMethod());
+
+        Map<String, String> expectedRequestHeaders2 = new HashMap<>();
+        expectedRequestHeaders2.put("X-Kii-AppID", APP_ID);
+        expectedRequestHeaders2.put("X-Kii-AppKey", APP_KEY);
+        expectedRequestHeaders2.put("Authorization", "Bearer " +
+                api.getOwner().getAccessToken());
+        this.assertRequestHeader(expectedRequestHeaders2, request2);
+    }
+
+    @Test
+    public void patchStateTriggerWithServerCodeAndPrecicateTest()
+        throws Exception
+    {
+        StatePredicate predicate = new StatePredicate(
+            new Condition(new Equals("power", true)),
+            TriggersWhen.CONDITION_CHANGED);
+        patchTriggerWithServerCodeAndOptionsTest(predicate, true, true, true);
+    }
+
+    @Test
+    public void patchStateTriggerWithNoServerCodeAndPrecicateTest()
+        throws Exception
+    {
+        StatePredicate predicate = new StatePredicate(
+            new Condition(new Equals("power", true)),
+            TriggersWhen.CONDITION_CHANGED);
+        patchTriggerWithServerCodeAndOptionsTest(predicate, false, true, true);
+    }
+
+    @Test
+    public void patchStateTriggerWithServerCodeAndPrecicateAndNoOptionsTest()
+        throws Exception
+    {
+        StatePredicate predicate = new StatePredicate(
+            new Condition(new Equals("power", true)),
+            TriggersWhen.CONDITION_CHANGED);
+        patchTriggerWithServerCodeAndOptionsTest(predicate, true, true, false);
+    }
+
+    @Test
+    public void patchScheduleOnceTriggerWithServerCodeAndPrecicateTest()
+        throws Exception
+    {
+        ScheduleOncePredicate predicate = new ScheduleOncePredicate(1000);
+        patchTriggerWithServerCodeAndOptionsTest(predicate, true, true, true);
+    }
+
+    @Test
+    public void patchScheduleOnceTriggerWithNoServerCodeAndPrecicateTest()
+        throws Exception
+    {
+        ScheduleOncePredicate predicate = new ScheduleOncePredicate(1000);
+        patchTriggerWithServerCodeAndOptionsTest(predicate, false, true, true);
+    }
+
+    @Test
+    public void patchScheduleOnceTriggerWithServerCodeAndPrecicateAndNoOptionsTest()
+        throws Exception
+    {
+        ScheduleOncePredicate predicate = new ScheduleOncePredicate(1000);
+        patchTriggerWithServerCodeAndOptionsTest(predicate, true, true, false);
+    }
+
+    @Test
+    public void patchTriggerWithServerCodeAndNoPrecicateAndNoOptionsTest()
+        throws Exception
+    {
+        ScheduleOncePredicate predicate = new ScheduleOncePredicate(1000);
+        patchTriggerWithServerCodeAndOptionsTest(predicate, true, false, false);
+    }
+
+    @Test
+    public void patchTriggerWithServerCodeAndNoPrecicateAndOptionsTest()
+        throws Exception
+    {
+        ScheduleOncePredicate predicate = new ScheduleOncePredicate(1000);
+        patchTriggerWithServerCodeAndOptionsTest(predicate, true, false, true);
+    }
+
+    @Test
+    public void patchTriggerNullTriggerID() throws Exception {
+        Schema schema = createDefaultSchema();
+        TypedID thingID = new TypedID(TypedID.Types.THING, "th.1234567890");
+        String accessToken = "thing-access-token-1234";
+        Target target = new StandaloneThing(thingID.getID(), "vendor-thing-id",
+                accessToken);
+        ThingIFAPI api = createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+
+        TriggerOptions options = TriggerOptions.Builder.newBuilder().
+                setTitle("title").
+                setDescription("description").
+                setMetadata(new JSONObject("{\"key\":\"value\"}")).build();
+        ServerCode serverCode = new ServerCode(
+            "function_name", "token12345", "app0001",
+            new JSONObject("{\"param\":\"p0001\"}"));
+        ScheduleOncePredicate predicate = new ScheduleOncePredicate(1000);
+
+        IllegalArgumentException actual = null;
+        ThingIFAPIUtils.setTarget(api, target);
+        try {
+            api.patchTrigger(null, serverCode, predicate, options);
+        } catch (IllegalArgumentException e) {
+            actual = e;
+        }
+        Assert.assertNotNull(actual);
+        Assert.assertEquals(actual.getMessage(), "triggerID is null or empty.");
+    }
+
+    @Test
+    public void patchTriggerEmptyTriggerID() throws Exception {
+        Schema schema = createDefaultSchema();
+        TypedID thingID = new TypedID(TypedID.Types.THING, "th.1234567890");
+        String accessToken = "thing-access-token-1234";
+        Target target = new StandaloneThing(thingID.getID(), "vendor-thing-id",
+                accessToken);
+        ThingIFAPI api = createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+
+        TriggerOptions options = TriggerOptions.Builder.newBuilder().
+                setTitle("title").
+                setDescription("description").
+                setMetadata(new JSONObject("{\"key\":\"value\"}")).build();
+        ServerCode serverCode = new ServerCode(
+            "function_name", "token12345", "app0001",
+            new JSONObject("{\"param\":\"p0001\"}"));
+        ScheduleOncePredicate predicate = new ScheduleOncePredicate(1000);
+
+        IllegalArgumentException actual = null;
+        ThingIFAPIUtils.setTarget(api, target);
+        try {
+            api.patchTrigger("", serverCode, predicate, options);
+        } catch (IllegalArgumentException e) {
+            actual = e;
+        }
+        Assert.assertNotNull(actual);
+        Assert.assertEquals(actual.getMessage(), "triggerID is null or empty");
+    }
+
+    @Test
+    public void patchTriggerOnlyTriggerID() throws Exception {
+        Schema schema = createDefaultSchema();
+        TypedID thingID = new TypedID(TypedID.Types.THING, "th.1234567890");
+        String accessToken = "thing-access-token-1234";
+        Target target = new StandaloneThing(thingID.getID(), "vendor-thing-id",
+                accessToken);
+        ThingIFAPI api = createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+
+        IllegalArgumentException actual = null;
+        ThingIFAPIUtils.setTarget(api, target);
+        try {
+            api.patchTrigger("triggerID", (ServerCode)null, null, null);
+        } catch (IllegalArgumentException e) {
+            actual = e;
+        }
+        Assert.assertNotNull(actual);
+        Assert.assertEquals(actual.getMessage(),
+                "serverCode, predicate and options are null.");
+    }
+
     @Test
     public void patchTrigger403ErrorTest() throws Exception {
         Schema schema = this.createDefaultSchema();

--- a/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PostNewTriggerForSchedulePredicateTest.java
+++ b/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PostNewTriggerForSchedulePredicateTest.java
@@ -182,6 +182,81 @@ public class ThingIFAPI_PostNewTriggerForSchedulePredicateTest
     }
 
     @Test
+    public void postNewTriggerWithServerCodeAndOptionsTest()
+        throws Exception
+    {
+        Schema schema = createDefaultSchema();
+        TypedID thingID = new TypedID(TypedID.Types.THING, "th.1234567890");
+        String accessToken = "thing-access-token-1234";
+        String triggerID = "trigger-1234";
+        Target target = new StandaloneThing(
+            thingID.getID(), "vendor-thing-id", accessToken);
+
+        Predicate predicate = new SchedulePredicate("1 * * * *");
+        ThingIFAPI api = createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+
+        TriggerOptions options =TriggerOptions.Builder.newBuilder().
+                setTitle("title").
+                setDescription("description").
+                setMetadata(new JSONObject("{\"key\":\"value\"}")).build();
+
+        ServerCode expectedServerCode = new ServerCode(
+            "function_name", "token12345", "app0001",
+            new JSONObject("{\"param\":\"p0001\"}"));
+        addMockResponseForPostNewTrigger(201, triggerID);
+        addMockResponseForGetTriggerWithServerCode(200, triggerID,
+                expectedServerCode, predicate, options, false, null, schema);
+
+        ThingIFAPIUtils.setTarget(api, target);
+        Trigger trigger = api.postNewTrigger(expectedServerCode,
+                predicate, options);
+        // verify the result
+        Assert.assertEquals(triggerID, trigger.getTriggerID());
+        Assert.assertEquals(false, trigger.disabled());
+        Assert.assertNull(trigger.getDisabledReason());
+        Assert.assertNull(trigger.getCommand());
+        assertPredicate(predicate, trigger.getPredicate());
+        assertServerCode(expectedServerCode, trigger.getServerCode());
+        assertTriggerOptions(options, trigger);
+        // verify the 1st request
+        RecordedRequest request1 = this.server.takeRequest(1, TimeUnit.SECONDS);
+        Assert.assertEquals(BASE_PATH + "/targets/" + thingID.toString() +
+                "/triggers", request1.getPath());
+        Assert.assertEquals("POST", request1.getMethod());
+
+        Map<String, String> expectedRequestHeaders1 = new HashMap<>();
+        expectedRequestHeaders1.put("X-Kii-AppID", APP_ID);
+        expectedRequestHeaders1.put("X-Kii-AppKey", APP_KEY);
+        expectedRequestHeaders1.put("Authorization",
+                "Bearer " + api.getOwner().getAccessToken());
+        expectedRequestHeaders1.put("Content-Type", "application/json");
+        assertRequestHeader(expectedRequestHeaders1, request1);
+
+        JsonObject expectedRequestBody =
+            GsonRepository.gson().toJsonTree(options).getAsJsonObject();
+        expectedRequestBody.add("serverCode",
+                GsonRepository.gson().toJsonTree(expectedServerCode));
+        expectedRequestBody.add("predicate",
+                GsonRepository.gson().toJsonTree(predicate));
+        expectedRequestBody.add("triggersWhat",
+                new JsonPrimitive("SERVER_CODE"));
+        assertRequestBody(expectedRequestBody, request1);
+
+        // verify the 2nd request
+        RecordedRequest request2 = this.server.takeRequest(1, TimeUnit.SECONDS);
+        Assert.assertEquals(BASE_PATH + "/targets/" + thingID.toString() +
+                "/triggers/" + triggerID, request2.getPath());
+        Assert.assertEquals("GET", request2.getMethod());
+
+        Map<String, String> expectedRequestHeaders2 = new HashMap<>();
+        expectedRequestHeaders2.put("X-Kii-AppID", APP_ID);
+        expectedRequestHeaders2.put("X-Kii-AppKey", APP_KEY);
+        expectedRequestHeaders2.put("Authorization",
+                "Bearer " + api.getOwner().getAccessToken());
+        assertRequestHeader(expectedRequestHeaders2, request2);
+    }
+
+    @Test
     public void postNewTrigger403ErrorTest() throws Exception {
         Schema schema = this.createDefaultSchema();
         TypedID thingID = new TypedID(TypedID.Types.THING, "th.1234567890");
@@ -675,7 +750,7 @@ public class ThingIFAPI_PostNewTriggerForSchedulePredicateTest
 
         ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
         ThingIFAPIUtils.setTarget(api, target);
-        api.postNewTrigger(null, predicate, null);
+        api.postNewTrigger((TriggeredCommandForm)null, predicate, null);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PostNewTriggerTest.java
+++ b/thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PostNewTriggerTest.java
@@ -260,6 +260,156 @@ public class ThingIFAPI_PostNewTriggerTest extends ThingIFAPITestBase {
     }
 
     @Test
+    public void postNewStateTriggerWithServerCodeAndOptionsTest()
+        throws Exception
+    {
+        StatePredicate predicate = new StatePredicate(
+            new Condition(
+                new Equals("power", true)), TriggersWhen.CONDITION_CHANGED);
+        Schema schema = createDefaultSchema();
+        TypedID thingID = new TypedID(TypedID.Types.THING, "th.1234567890");
+        String accessToken = "thing-access-token-1234";
+        String triggerID = "trigger-1234";
+        Target target = new StandaloneThing(
+            thingID.getID(), "vendor-thing-id", accessToken);
+        ThingIFAPI api = createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+
+        TriggerOptions options =TriggerOptions.Builder.newBuilder().
+                setTitle("title").
+                setDescription("description").
+                setMetadata(new JSONObject("{\"key\":\"value\"}")).build();
+
+        ServerCode expectedServerCode =
+                new ServerCode("function_name", "token12345", "app0001",
+                        new JSONObject("{\"param\":\"p0001\"}"));
+        addMockResponseForPostNewTrigger(201, triggerID);
+        addMockResponseForGetTriggerWithServerCode(
+            200, triggerID, expectedServerCode, predicate, options, false, null,
+            schema);
+
+        ThingIFAPIUtils.setTarget(api, target);
+        Trigger trigger = api.postNewTrigger(expectedServerCode, predicate,
+                options);
+        // verify the result
+        Assert.assertEquals(triggerID, trigger.getTriggerID());
+        Assert.assertEquals(false, trigger.disabled());
+        Assert.assertNull(trigger.getDisabledReason());
+        Assert.assertNull(trigger.getCommand());
+        assertPredicate(predicate, trigger.getPredicate());
+        assertServerCode(expectedServerCode, trigger.getServerCode());
+        assertTriggerOptions(options, trigger);
+        // verify the 1st request
+        RecordedRequest request1 = this.server.takeRequest(1, TimeUnit.SECONDS);
+        Assert.assertEquals(BASE_PATH + "/targets/" + thingID.toString() +
+                "/triggers", request1.getPath());
+        Assert.assertEquals("POST", request1.getMethod());
+
+        Map<String, String> expectedRequestHeaders1 = new HashMap<>();
+        expectedRequestHeaders1.put("X-Kii-AppID", APP_ID);
+        expectedRequestHeaders1.put("X-Kii-AppKey", APP_KEY);
+        expectedRequestHeaders1.put("Authorization",
+                "Bearer " + api.getOwner().getAccessToken());
+        expectedRequestHeaders1.put("Content-Type", "application/json");
+        assertRequestHeader(expectedRequestHeaders1, request1);
+
+        JsonObject expectedRequestBody =
+            GsonRepository.gson().toJsonTree(options).getAsJsonObject();
+        expectedRequestBody.add("serverCode",
+                GsonRepository.gson().toJsonTree(expectedServerCode));
+        expectedRequestBody.add("predicate",
+                GsonRepository.gson().toJsonTree(predicate));
+        expectedRequestBody.add("triggersWhat",
+                new JsonPrimitive("SERVER_CODE"));
+        assertRequestBody(expectedRequestBody, request1);
+
+        // verify the 2nd request
+        RecordedRequest request2 = this.server.takeRequest(1, TimeUnit.SECONDS);
+        Assert.assertEquals(BASE_PATH + "/targets/" + thingID.toString() +
+                "/triggers/" + triggerID, request2.getPath());
+        Assert.assertEquals("GET", request2.getMethod());
+
+        Map<String, String> expectedRequestHeaders2 = new HashMap<>();
+        expectedRequestHeaders2.put("X-Kii-AppID", APP_ID);
+        expectedRequestHeaders2.put("X-Kii-AppKey", APP_KEY);
+        expectedRequestHeaders2.put("Authorization",
+                "Bearer " + api.getOwner().getAccessToken());
+        assertRequestHeader(expectedRequestHeaders2, request2);
+    }
+
+    @Test
+    public void postNewStateTriggerWithServerCodeAndNullOptionsTest()
+        throws Exception
+    {
+        StatePredicate predicate = new StatePredicate(
+            new Condition(
+                new Equals("power", true)), TriggersWhen.CONDITION_CHANGED);
+        Schema schema = createDefaultSchema();
+        TypedID thingID = new TypedID(TypedID.Types.THING, "th.1234567890");
+        String accessToken = "thing-access-token-1234";
+        String triggerID = "trigger-1234";
+        Target target = new StandaloneThing(
+            thingID.getID(), "vendor-thing-id", accessToken);
+        ThingIFAPI api = createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+
+        ServerCode expectedServerCode =
+                new ServerCode("function_name", "token12345", "app0001",
+                        new JSONObject("{\"param\":\"p0001\"}"));
+        addMockResponseForPostNewTrigger(201, triggerID);
+        addMockResponseForGetTriggerWithServerCode(
+            200, triggerID, expectedServerCode, predicate, null, false, null,
+            schema);
+
+        ThingIFAPIUtils.setTarget(api, target);
+        Trigger trigger = api.postNewTrigger(expectedServerCode, predicate,
+                null);
+        // verify the result
+        Assert.assertEquals(triggerID, trigger.getTriggerID());
+        Assert.assertEquals(false, trigger.disabled());
+        Assert.assertNull(trigger.getDisabledReason());
+        Assert.assertNull(trigger.getCommand());
+        assertPredicate(predicate, trigger.getPredicate());
+        assertServerCode(expectedServerCode, trigger.getServerCode());
+        Assert.assertNull(trigger.getTitle());
+        Assert.assertNull(trigger.getDescription());
+        Assert.assertNull(trigger.getMetadata());
+        // verify the 1st request
+        RecordedRequest request1 = this.server.takeRequest(1, TimeUnit.SECONDS);
+        Assert.assertEquals(BASE_PATH + "/targets/" + thingID.toString() +
+                "/triggers", request1.getPath());
+        Assert.assertEquals("POST", request1.getMethod());
+
+        Map<String, String> expectedRequestHeaders1 = new HashMap<>();
+        expectedRequestHeaders1.put("X-Kii-AppID", APP_ID);
+        expectedRequestHeaders1.put("X-Kii-AppKey", APP_KEY);
+        expectedRequestHeaders1.put("Authorization",
+                "Bearer " + api.getOwner().getAccessToken());
+        expectedRequestHeaders1.put("Content-Type", "application/json");
+        assertRequestHeader(expectedRequestHeaders1, request1);
+
+        JsonObject expectedRequestBody = new JsonObject();
+        expectedRequestBody.add("serverCode",
+                GsonRepository.gson().toJsonTree(expectedServerCode));
+        expectedRequestBody.add("predicate",
+                GsonRepository.gson().toJsonTree(predicate));
+        expectedRequestBody.add("triggersWhat",
+                new JsonPrimitive("SERVER_CODE"));
+        assertRequestBody(expectedRequestBody, request1);
+
+        // verify the 2nd request
+        RecordedRequest request2 = this.server.takeRequest(1, TimeUnit.SECONDS);
+        Assert.assertEquals(BASE_PATH + "/targets/" + thingID.toString() +
+                "/triggers/" + triggerID, request2.getPath());
+        Assert.assertEquals("GET", request2.getMethod());
+
+        Map<String, String> expectedRequestHeaders2 = new HashMap<>();
+        expectedRequestHeaders2.put("X-Kii-AppID", APP_ID);
+        expectedRequestHeaders2.put("X-Kii-AppKey", APP_KEY);
+        expectedRequestHeaders2.put("Authorization",
+                "Bearer " + api.getOwner().getAccessToken());
+        assertRequestHeader(expectedRequestHeaders2, request2);
+    }
+
+    @Test
     public void postNewTrigger403ErrorTest() throws Exception {
         Schema schema = this.createDefaultSchema();
         TypedID thingID = new TypedID(TypedID.Types.THING, "th.1234567890");
@@ -635,7 +785,7 @@ public class ThingIFAPI_PostNewTriggerTest extends ThingIFAPITestBase {
 
         ThingIFAPI api = this.createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
         ThingIFAPIUtils.setTarget(api, target);
-        api.postNewTrigger(null,
+        api.postNewTrigger((TriggeredCommandForm)null,
                 predicate,
                 TriggerOptions.Builder.newBuilder().setTitle("title").build());
     }
@@ -661,4 +811,52 @@ public class ThingIFAPI_PostNewTriggerTest extends ThingIFAPITestBase {
             null,
             TriggerOptions.Builder.newBuilder().setTitle("title").build());
     }
+
+    public void postNewStateTriggerWithNullServerCodeTest()
+        throws Exception
+    {
+        StatePredicate predicate = new StatePredicate(
+            new Condition(
+                new Equals("power", true)), TriggersWhen.CONDITION_CHANGED);
+        ThingIFAPI api = createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        TypedID thingID = new TypedID(TypedID.Types.THING, "th.1234567890");
+        String accessToken = "thing-access-token-1234";
+        Target target = new StandaloneThing(thingID.getID(), "vendor-thing-id",
+                accessToken);
+        ThingIFAPIUtils.setTarget(api, target);
+
+        IllegalArgumentException actual = null;
+        try {
+            api.postNewTrigger((ServerCode)null, predicate, null);
+        } catch (IllegalArgumentException e) {
+            actual = e;
+        }
+        Assert.assertNotNull(actual);
+        Assert.assertEquals(actual.getMessage(), "serverCode is null");
+    }
+
+    public void postNewStateTriggerWithNullPredicate()
+        throws Exception
+    {
+
+        ServerCode serverCode = new ServerCode("function_name", "token12345",
+                "app0001", new JSONObject("{\"param\":\"p0001\"}"));
+
+        ThingIFAPI api = createThingIFAPIWithDemoSchema(APP_ID, APP_KEY);
+        TypedID thingID = new TypedID(TypedID.Types.THING, "th.1234567890");
+        String accessToken = "thing-access-token-1234";
+        Target target = new StandaloneThing(thingID.getID(), "vendor-thing-id",
+                accessToken);
+        ThingIFAPIUtils.setTarget(api, target);
+
+        IllegalArgumentException actual = null;
+        try {
+            api.postNewTrigger(serverCode, null, null);
+        } catch (IllegalArgumentException e) {
+            actual = e;
+        }
+        Assert.assertNotNull(actual);
+        Assert.assertEquals(actual.getMessage(), "predicate is null");
+    }
+
 }

--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -911,6 +911,34 @@ public class ThingIFAPI implements Parcelable {
      *
      * @param serverCode Specify server code you want to execute.
      * @param predicate Specify when the Trigger fires command.
+     * @param options option fileds of this trigger.
+     * @return Instance of the Trigger registered in IoT Cloud.
+     * @throws ThingIFException Thrown when failed to connect IoT Cloud Server.
+     * @throws ThingIFRestException Thrown when server returns error response.
+     */
+    @NonNull
+    @WorkerThread
+    public Trigger postNewTrigger(
+            @NonNull ServerCode serverCode,
+            @NonNull Predicate predicate,
+            @Nullable TriggerOptions options)
+        throws ThingIFException
+    {
+        // TODO: implement me.
+        return null;
+    }
+
+    /**
+     * Post new Trigger with server code to IoT Cloud.
+     *
+     * <p>
+     * Limited version of {@link #postNewTrigger(ServerCode, Predicate,
+     * TriggerOptions)}. This method can not be set title, description and
+     * metadata of {@link Trigger}.
+     * </p>
+     *
+     * @param serverCode Specify server code you want to execute.
+     * @param predicate Specify when the Trigger fires command.
      * @return Instance of the Trigger registered in IoT Cloud.
      * @throws ThingIFException Thrown when failed to connect IoT Cloud Server.
      * @throws ThingIFRestException Thrown when server returns error response.

--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -1186,9 +1186,10 @@ public class ThingIFAPI implements Parcelable {
             @Nullable TriggerOptions options)
         throws ThingIFException
     {
-        // TODO: implement me.
-        return null;
+        return patchServerCodeTrigger(triggerID, serverCode, predicate,
+                options);
     }
+
     /**
      * Apply Patch to registered Trigger
      * Modify registered Trigger with specified patch.
@@ -1215,25 +1216,53 @@ public class ThingIFAPI implements Parcelable {
             @NonNull String triggerID,
             @Nullable ServerCode serverCode,
             @Nullable Predicate predicate) throws ThingIFException {
+        if (serverCode == null && predicate == null) {
+            throw new IllegalArgumentException(
+                "serverCode and predicate are null.");
+        }
+        return patchServerCodeTrigger(triggerID, serverCode, predicate, null);
+    }
+
+    @NonNull
+    @WorkerThread
+    private Trigger patchServerCodeTrigger(
+            @NonNull String triggerID,
+            @Nullable ServerCode serverCode,
+            @Nullable Predicate predicate,
+            @Nullable TriggerOptions options)
+        throws ThingIFException
+    {
         if (this.target == null) {
             throw new IllegalStateException("Can not perform this action before onboarding");
         }
         if (TextUtils.isEmpty(triggerID)) {
             throw new IllegalArgumentException("triggerID is null or empty");
         }
-        if (serverCode == null) {
-            throw new IllegalArgumentException("serverCode is null");
+        if (serverCode == null && predicate == null && options == null) {
+            throw new IllegalArgumentException(
+                "serverCode, predicate and options are null.");
         }
-        if (predicate == null) {
-            throw new IllegalArgumentException("predicate is null");
-        }
-        JSONObject requestBody = new JSONObject();
+        JSONObject requestBody = null;
         try {
-            requestBody.put("predicate", JsonUtils.newJson(GsonRepository.gson().toJson(predicate)));
-            requestBody.put("serverCode", JsonUtils.newJson(GsonRepository.gson().toJson(serverCode)));
+            if (options != null) {
+                requestBody = JsonUtils.newJson(
+                    GsonRepository.gson().toJson(options));
+            } else {
+                requestBody = new JSONObject();
+            }
+            if (predicate != null) {
+                requestBody.put("predicate",
+                        JsonUtils.newJson(
+                            GsonRepository.gson().toJson(predicate)));
+            }
+            if (serverCode != null) {
+                requestBody.put("serverCode",
+                        JsonUtils.newJson(
+                            GsonRepository.gson().toJson(serverCode)));
+            }
             requestBody.put("triggersWhat", TriggersWhat.SERVER_CODE.name());
         } catch (JSONException e) {
-            // Won’t happen
+            // Won't happen
         }
         return this.patchTrigger(triggerID, requestBody);
     }

--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -1149,11 +1149,58 @@ public class ThingIFAPI implements Parcelable {
         }
         return this.patchTrigger(triggerID, requestBody);
     }
+
+    /**
+     * Apply Patch to registered Trigger
+     * Modify registered Trigger with specified patch.
+     *
+     * @param triggerID ID ot the Trigger to apply patch
+     * @param serverCode Specify server code you want to execute.
+     * @param predicate Modified predicate.
+     * @param options option fileds of this trigger.
+     * @return Updated Trigger instance.
+     * @throws ThingIFException Thrown when failed to connect IoT Cloud Server.
+     * @throws ThingIFRestException Thrown when server returns error response.
+     * @throws IllegalArgumentException when all of  serverCode, predicates
+     * and options are null.
+     */
     @NonNull
     @WorkerThread
     public Trigger patchTrigger(
             @NonNull String triggerID,
-            @NonNull ServerCode serverCode,
+            @Nullable ServerCode serverCode,
+            @Nullable Predicate predicate,
+            @Nullable TriggerOptions options)
+        throws ThingIFException
+    {
+        // TODO: implement me.
+        return null;
+    }
+    /**
+     * Apply Patch to registered Trigger
+     * Modify registered Trigger with specified patch.
+     *
+     * <p>
+     * Limited version of {@link #patchTrigger(String, ServerCode, Predicate,
+     * TriggerOptions)}
+     * <p>
+     *
+     * @param triggerID ID ot the Trigger to apply patch
+     * @param serverCode Specify server code you want to execute. If null,
+     * predicate must not be null.
+     * @param predicate Modified predicate. If null, serverCode must not be
+     * null.
+     * @return Updated Trigger instance.
+     * @throws ThingIFException Thrown when failed to connect IoT Cloud Server.
+     * @throws ThingIFRestException Thrown when server returns error response.
+     * @throws IllegalArgumentException when both server and predicates are
+     * null.
+     */
+    @NonNull
+    @WorkerThread
+    public Trigger patchTrigger(
+            @NonNull String triggerID,
+            @Nullable ServerCode serverCode,
             @Nullable Predicate predicate) throws ThingIFException {
         if (this.target == null) {
             throw new IllegalStateException("Can not perform this action before onboarding");

--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -924,8 +924,7 @@ public class ThingIFAPI implements Parcelable {
             @Nullable TriggerOptions options)
         throws ThingIFException
     {
-        // TODO: implement me.
-        return null;
+        return postServerCodeNewTrigger(serverCode, predicate, options);
     }
 
     /**
@@ -949,8 +948,20 @@ public class ThingIFAPI implements Parcelable {
             @NonNull ServerCode serverCode,
             @NonNull Predicate predicate)
             throws ThingIFException {
+        return postServerCodeNewTrigger(serverCode, predicate, null);
+    }
+
+    @NonNull
+    @WorkerThread
+    public Trigger postServerCodeNewTrigger(
+            @NonNull ServerCode serverCode,
+            @NonNull Predicate predicate,
+            @Nullable TriggerOptions options)
+        throws ThingIFException
+    {
         if (this.target == null) {
-            throw new IllegalStateException("Can not perform this action before onboarding");
+            throw new IllegalStateException(
+                "Can not perform this action before onboarding");
         }
         if (serverCode == null) {
             throw new IllegalArgumentException("serverCode is null");
@@ -958,13 +969,15 @@ public class ThingIFAPI implements Parcelable {
         if (predicate == null) {
             throw new IllegalArgumentException("predicate is null");
         }
-        JSONObject requestBody = new JSONObject();
+        JSONObject requestBody = options != null ?
+                JsonUtils.newJson(GsonRepository.gson().toJson(options)) :
+                new JSONObject();
         try {
             requestBody.put("predicate", JsonUtils.newJson(GsonRepository.gson().toJson(predicate)));
             requestBody.put("triggersWhat", TriggersWhat.SERVER_CODE.name());
             requestBody.put("serverCode", JsonUtils.newJson(GsonRepository.gson().toJson(serverCode)));
         } catch (JSONException e) {
-            // Won’t happen
+            // Won't happen
         }
         return this.postNewTrigger(requestBody);
     }


### PR DESCRIPTION
New `postNewTrigger` and `patchTrigger` for server code is designed.

### Issue

Current `postNewTrigger` and `patchTrigger` for server code can not send title, description and metadata fields

In this PR, New `postNewTrigger` and `patchTrigger` for server code is designed. The methods can send title, description and metadata.

### New APIs

  * `ThingIFAPI#postNewTrigger(ServerCode, Predicate, TriggerOptions)`
  * `ThingIFAPI#patchTrigger(String, ServerCode, Predicate, TriggerOptions)`

### Modified APIs
  * `ThingIFAPI#patchTrigger(String, ServerCode, Predicate)`

Argument `ServerCode` declares as `@NonNull`. it becomes `@Nullable`.
This change maintains backward compatibility.

### Tests

  * thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PatchTriggerTest.java
  * thingif/srcc/androidTest/java/com/kii/thingif/ThingIFAPI_PostNewTriggerForSchedulePredicateTest.java
  * thingif/src/androidTest/java/com/kii/thingif/ThingIFAPI_PostNewTriggerTest.java
### Reference

Related issue: No. 974
Release version: 0.13.0