### PR TITLE
Redundant public method becomes private.

### DIFF
--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -953,7 +953,7 @@ public class ThingIFAPI implements Parcelable {
 
     @NonNull
     @WorkerThread
-    public Trigger postServerCodeNewTrigger(
+    private Trigger postServerCodeNewTrigger(
             @NonNull ServerCode serverCode,
             @NonNull Predicate predicate,
             @Nullable TriggerOptions options)


### PR DESCRIPTION
新しく作成したprivateメソッドのaccess modifierがpublicになっていたので修正しました。