### PR TITLE
Add command APIs to TraitThingIFAPI

### DIFF
--- a/thingif/src/main/java/com/kii/thingif/TraitThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/TraitThingIFAPI.java
@@ -9,7 +9,6 @@ import android.support.annotation.Nullable;
 import android.support.annotation.WorkerThread;
 import android.util.Pair;
 
-import com.kii.thingif.command.Command;
 import com.kii.thingif.command.TraitCommand;
 import com.kii.thingif.command.TraitCommandForm;
 import com.kii.thingif.exception.StoredThingIFAPIInstanceNotFoundException;

--- a/thingif/src/main/java/com/kii/thingif/TraitThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/TraitThingIFAPI.java
@@ -7,13 +7,21 @@ import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.WorkerThread;
+import android.util.Pair;
 
+import com.kii.thingif.command.Command;
+import com.kii.thingif.command.TraitCommand;
+import com.kii.thingif.command.TraitCommandForm;
 import com.kii.thingif.exception.StoredThingIFAPIInstanceNotFoundException;
 import com.kii.thingif.exception.ThingIFException;
 import com.kii.thingif.exception.ThingIFRestException;
+import com.kii.thingif.exception.UnsupportedActionException;
+import com.kii.thingif.exception.UnsupportedSchemaException;
 import com.kii.thingif.gateway.EndNode;
 import com.kii.thingif.gateway.PendingEndNode;
 import com.kii.thingif.internal.GsonRepository;
+
+import java.util.List;
 
 public class TraitThingIFAPI implements Parcelable{
     private static Context context;
@@ -551,6 +559,75 @@ public class TraitThingIFAPI implements Parcelable{
     @NonNull
     public static String getSDKVersion() {
         return ThingIFAPI.getSDKVersion();
+    }
+
+    /**
+     * Post new command to IoT Cloud.
+     * Command will be delivered to specified target and result will be notified
+     * through push notification.
+     * @param form form of command. It contains name of schema, version of
+     * schema, list of actions etc.
+     * @return Created Command instance. At this time, Command is delivered to
+     * the target Asynchronously and may not finished. Actual Result will be
+     * delivered through push notification or you can check the latest status
+     * of the command by calling {@link #getCommand}.
+     * @throws ThingIFException Thrown when failed to connect IoT Cloud Server.
+     * @throws ThingIFRestException Thrown when server returns error response.
+     */
+    @NonNull
+    @WorkerThread
+    public TraitCommand postNewCommand(TraitCommandForm form) throws ThingIFException {
+        //TODO: implement me
+        return null;
+    }
+
+    /**
+     * Get specified command.
+     * @param commandID ID of the command to obtain. ID is present in the
+     *                  instance returned by {@link #postNewCommand}
+     *                  and can be obtained by {@link TraitCommand#getCommandID}
+     *
+     * @return Command instance.
+     * @throws ThingIFException Thrown when failed to connect IoT Cloud Server.
+     * @throws ThingIFRestException Thrown when server returns error response.
+     * @throws UnsupportedSchemaException Thrown when the returned response has a schema that cannot handle this instance.
+     * @throws UnsupportedActionException Thrown when the returned response has a action that cannot handle this instance.
+     */
+    @NonNull
+    @WorkerThread
+    public TraitCommand getCommand(
+            @NonNull String commandID)
+            throws ThingIFException {
+        //TODO: implement me
+        return null;
+    }
+
+    /**
+     * List TraitCommands in the specified Target.
+     * @param bestEffortLimit Maximum number of the Commands in the response.
+     *                        if the value is {@literal <}= 0, default limit internally
+     *                        defined is applied.
+     *                        Meaning of 'bestEffort' is if the specified limit
+     *                        is greater than default limit, default limit is
+     *                        applied.
+     * @param paginationKey Used to get the next page of previously obtained.
+     *                      If there is further page to obtain, this method
+     *                      returns paginationKey as the 2nd element of pair.
+     *                      Applying this key to the argument results continue
+     *                      to get the result from the next page.
+     * @return 1st Element is TraitCommands belongs to the Target. 2nd element is
+     * paginationKey if there is next page to be obtained.
+     * @throws ThingIFException Thrown when failed to connect IoT Cloud Server.
+     * @throws ThingIFRestException Thrown when server returns error response.
+     * @throws UnsupportedActionException Thrown when the returned response has a action that cannot handle this instance.
+     */
+    @NonNull
+    public Pair<List<TraitCommand>, String> listCommands (
+            int bestEffortLimit,
+            @Nullable String paginationKey)
+            throws ThingIFException {
+        //TODO: implement me
+        return null;
     }
 
     private static SharedPreferences getSharedPreferences() {

--- a/thingif/src/main/java/com/kii/thingif/command/AbstractCommand.java
+++ b/thingif/src/main/java/com/kii/thingif/command/AbstractCommand.java
@@ -1,0 +1,187 @@
+package com.kii.thingif.command;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.text.TextUtils;
+
+import com.google.gson.annotations.SerializedName;
+import com.kii.thingif.TypedID;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+class AbstractCommand implements Parcelable{
+    private @Nullable String commandID;
+    @SerializedName("target")
+    private @Nullable final TypedID targetID;
+    @SerializedName("issuer")
+    private @NonNull final TypedID issuerID;
+    @SerializedName("commandState")
+    private @Nullable CommandState commandState;
+    private @Nullable String firedByTriggerID;
+    @SerializedName("createdAt")
+    private @Nullable Long created;
+    @SerializedName("modifiedAt")
+    private @Nullable Long modified;
+    private @Nullable String title;
+    private @Nullable String description;
+    private @Nullable JSONObject metadata;
+
+    AbstractCommand(
+                   @NonNull TypedID targetID,
+                   @NonNull TypedID issuerID) {
+        if (targetID == null) {
+            throw new IllegalArgumentException("targetID is null");
+        }
+        if (issuerID == null) {
+            throw new IllegalArgumentException("issuerID is null");
+        }
+        this.targetID = targetID;
+        this.issuerID = issuerID;
+    }
+    AbstractCommand(
+                   @NonNull TypedID issuerID) {
+        if (issuerID == null) {
+            throw new IllegalArgumentException("issuerID is null");
+        }
+        this.targetID = null;
+        this.issuerID = issuerID;
+    }
+
+    /** Get ID of the command.
+     * @return ID of the command.
+     */
+    @Nullable
+    public String getCommandID() {
+        return this.commandID;
+    }
+
+    /**
+     * Get ID of the target thing.
+     * @return target thing ID which is issued this command.
+     */
+    @Nullable
+    public TypedID getTargetID() {
+        return this.targetID;
+    }
+
+    /**
+     * Get ID of the issuer user.
+     * @return issuer ID by which this command is issued.
+     */
+    @NonNull
+    public TypedID getIssuerID() {
+        return this.issuerID;
+    }
+
+
+    /**
+     * Get status of command
+     * @return status of this command.
+     */
+    @Nullable
+    public CommandState getCommandState() {
+        return this.commandState;
+    }
+
+    /**
+     * Get ID of trigger which fired this command
+     * @return trigger ID which fired this command.
+     */
+    @Nullable
+    public String getFiredByTriggerID() {
+        return this.firedByTriggerID;
+    }
+
+    /**
+     * Get creation time
+     * @return creation time of this command.
+     */
+    @Nullable
+    public Long getCreated() {
+        return this.created;
+    }
+    /**
+     * Get modification time
+     * @return modification time of this command.
+     */
+    @Nullable
+    public Long getModified() {
+        return this.modified;
+    }
+    /**
+     * Get title.
+     * @return title of this command.
+     */
+    @Nullable
+    public String getTitle() {
+        return this.title;
+    }
+    /**
+     * Get description.
+     * @return description of this command.
+     */
+    @Nullable
+    public String getDescription() {
+        return this.description;
+    }
+    /**
+     * Get meta data
+     * @return meta data of this command.
+     */
+    @Nullable
+    public JSONObject getMetadata() {
+        return this.metadata;
+    }
+
+    // Implementation of Parcelable
+    AbstractCommand(Parcel in) {
+        this.commandID = in.readString();
+        this.targetID = in.readParcelable(TypedID.class.getClassLoader());
+        this.issuerID = in.readParcelable(TypedID.class.getClassLoader());
+        this.commandState = (CommandState)in.readSerializable();
+        this.firedByTriggerID = in.readString();
+        this.created = (Long)in.readValue(Command.class.getClassLoader());
+        this.modified = (Long)in.readValue(Command.class.getClassLoader());
+        this.title = in.readString();
+        this.description = in.readString();
+        String metadata = in.readString();
+        if (!TextUtils.isEmpty(metadata)) {
+            try {
+                this.metadata = new JSONObject(metadata);
+            } catch (JSONException ignore) {
+                // Won’t happen
+            }
+        }
+    }
+    public static final Parcelable.Creator<AbstractCommand> CREATOR = new Parcelable.Creator<AbstractCommand>() {
+        @Override
+        public AbstractCommand createFromParcel(Parcel in) {
+            return new AbstractCommand(in);
+        }
+
+        @Override
+        public AbstractCommand[] newArray(int size) {
+            return new AbstractCommand[size];
+        }
+    };
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(this.commandID);
+        dest.writeParcelable(this.targetID, flags);
+        dest.writeParcelable(this.issuerID, flags);
+        dest.writeSerializable(this.commandState);
+        dest.writeString(this.firedByTriggerID);
+        dest.writeValue(this.created);
+        dest.writeValue(this.modified);
+        dest.writeString(this.title);
+        dest.writeString(this.description);
+        dest.writeString(this.metadata == null ? null : this.metadata.toString());
+    }
+}

--- a/thingif/src/main/java/com/kii/thingif/command/Command.java
+++ b/thingif/src/main/java/com/kii/thingif/command/Command.java
@@ -5,82 +5,35 @@ import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
-import com.google.gson.annotations.SerializedName;
 import com.kii.thingif.TypedID;
-
-import org.json.JSONException;
-import org.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.List;
 
-
 /**
  * Represents a command that is executed by the thing
  */
-public class Command implements Parcelable {
+public class Command extends AbstractCommand implements Parcelable {
 
-    private String commandID;
-    @SerializedName("schema")
-    private final String schemaName;
-    private final int schemaVersion;
-    @SerializedName("target")
-    private final TypedID targetID;
-    @SerializedName("issuer")
-    private final TypedID issuerID;
     private final List<Action> actions;
     private List<ActionResult> actionResults;
-    @SerializedName("commandState")
-    private CommandState commandState;
-    private String firedByTriggerID;
-    @SerializedName("createdAt")
-    private Long created;
-    @SerializedName("modifiedAt")
-    private Long modified;
-    private String title;
-    private String description;
-    private JSONObject metadata;
 
-    public Command(@NonNull String schemaName,
-                   int schemaVersion,
-                   @NonNull TypedID targetID,
+    public Command(@NonNull TypedID targetID,
                    @NonNull TypedID issuerID,
                    @NonNull List<Action> actions) {
-        if (TextUtils.isEmpty(schemaName)) {
-            throw new IllegalArgumentException("schemaName is null or empty");
-        }
-        if (targetID == null) {
-            throw new IllegalArgumentException("targetID is null");
-        }
-        if (issuerID == null) {
-            throw new IllegalArgumentException("issuerID is null");
-        }
+        super(targetID, issuerID);
         if (actions == null || actions.size() == 0) {
             throw new IllegalArgumentException("actions is null or empty");
         }
-        this.schemaName = schemaName;
-        this.schemaVersion = schemaVersion;
-        this.targetID = targetID;
-        this.issuerID = issuerID;
         this.actions = actions;
     }
-    public Command(@NonNull String schemaName,
-                   int schemaVersion,
+    public Command(
                    @NonNull TypedID issuerID,
                    @NonNull List<Action> actions) {
-        if (TextUtils.isEmpty(schemaName)) {
-            throw new IllegalArgumentException("schemaName is null or empty");
-        }
-        if (issuerID == null) {
-            throw new IllegalArgumentException("issuerID is null");
-        }
+        super(issuerID);
         if (actions == null || actions.size() == 0) {
             throw new IllegalArgumentException("actions is null or empty");
         }
-        this.schemaName = schemaName;
-        this.schemaVersion = schemaVersion;
-        this.targetID = null;
-        this.issuerID = issuerID;
         this.actions = actions;
     }
     public void addActionResult(@NonNull ActionResult ar) {
@@ -100,43 +53,6 @@ public class Command implements Parcelable {
             this.actionResults = new ArrayList<ActionResult>();
         }
         this.actionResults.add(ar);
-    }
-
-    /** Get ID of the command.
-     * @return ID of the command.
-     */
-    public String getCommandID() {
-        return this.commandID;
-    }
-
-    /** Get name of the schema in which command is defined.
-     * @return name of the schema.
-     */
-    public String getSchemaName() {
-        return this.schemaName;
-    }
-
-    /** Get version of the schema in which command is defined.
-     * @return version of the schema.
-     */
-    public int getSchemaVersion() {
-        return this.schemaVersion;
-    }
-
-    /**
-     * Get ID of the target thing.
-     * @return target thing ID which is issued this command.
-     */
-    public TypedID getTargetID() {
-        return this.targetID;
-    }
-
-    /**
-     * Get ID of the issuer user.
-     * @return issuer ID by which this command is issued.
-     */
-    public TypedID getIssuerID() {
-        return this.issuerID;
     }
 
     /**
@@ -175,83 +91,14 @@ public class Command implements Parcelable {
         return null;
     }
 
-    /**
-     * Get status of command
-     * @return status of this command.
-     */
-    public CommandState getCommandState() {
-        return this.commandState;
-    }
-
-    /**
-     * Get ID of trigger which fired this command
-     * @return trigger ID which fired this command.
-     */
-    public String getFiredByTriggerID() {
-        return this.firedByTriggerID;
-    }
-
-    /**
-     * Get creation time
-     * @return creation time of this command.
-     */
-    public Long getCreated() {
-        return this.created;
-    }
-    /**
-     * Get modification time
-     * @return modification time of this command.
-     */
-    public Long getModified() {
-        return this.modified;
-    }
-    /**
-     * Get title.
-     * @return title of this command.
-     */
-    public String getTitle() {
-        return this.title;
-    }
-    /**
-     * Get description.
-     * @return description of this command.
-     */
-    public String getDescription() {
-        return this.description;
-    }
-    /**
-     * Get meta data
-     * @return meta data of this command.
-     */
-    public JSONObject getMetadata() {
-        return this.metadata;
-    }
 
     // Implementation of Parcelable
     protected Command(Parcel in) {
-        this.commandID = in.readString();
-        this.schemaName = in.readString();
-        this.schemaVersion = in.readInt();
-        this.targetID = in.readParcelable(TypedID.class.getClassLoader());
-        this.issuerID = in.readParcelable(TypedID.class.getClassLoader());
+        super(in);
         this.actions = new ArrayList<Action>();
         in.readList(this.actions, Command.class.getClassLoader());
         this.actionResults = new ArrayList<ActionResult>();
         in.readList(this.actionResults, Command.class.getClassLoader());
-        this.commandState = (CommandState)in.readSerializable();
-        this.firedByTriggerID = in.readString();
-        this.created = (Long)in.readValue(Command.class.getClassLoader());
-        this.modified = (Long)in.readValue(Command.class.getClassLoader());
-        this.title = in.readString();
-        this.description = in.readString();
-        String metadata = in.readString();
-        if (!TextUtils.isEmpty(metadata)) {
-            try {
-                this.metadata = new JSONObject(metadata);
-            } catch (JSONException ignore) {
-                // Won’t happen
-            }
-        }
     }
     public static final Creator<Command> CREATOR = new Creator<Command>() {
         @Override
@@ -270,19 +117,8 @@ public class Command implements Parcelable {
     }
     @Override
     public void writeToParcel(Parcel dest, int flags) {
-        dest.writeString(this.commandID);
-        dest.writeString(this.schemaName);
-        dest.writeInt(this.schemaVersion);
-        dest.writeParcelable(this.targetID, flags);
-        dest.writeParcelable(this.issuerID, flags);
+        super.writeToParcel(dest, flags);
         dest.writeList(this.actions);
         dest.writeList(this.actionResults);
-        dest.writeSerializable(this.commandState);
-        dest.writeString(this.firedByTriggerID);
-        dest.writeValue(this.created);
-        dest.writeValue(this.modified);
-        dest.writeString(this.title);
-        dest.writeString(this.description);
-        dest.writeString(this.metadata == null ? null : this.metadata.toString());
     }
 }

--- a/thingif/src/main/java/com/kii/thingif/command/TraitCommand.java
+++ b/thingif/src/main/java/com/kii/thingif/command/TraitCommand.java
@@ -1,0 +1,139 @@
+package com.kii.thingif.command;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+import com.kii.thingif.TypedID;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents a trait formatted command that is executed by the thing
+ */
+public class TraitCommand extends AbstractCommand implements Parcelable {
+
+    private @NonNull final Map<String, List<Action>> actions;
+    private @NonNull Map<String, List<ActionResult>> actionResults;
+
+    public TraitCommand(
+                   @NonNull TypedID targetID,
+                   @NonNull TypedID issuerID,
+                   @NonNull Map<String, List<Action>> actions) {
+        super(targetID, issuerID);
+        if (actions == null || actions.size() == 0) {
+            throw new IllegalArgumentException("actions is null or empty");
+        }
+        this.actions = actions;
+        this.actionResults = new HashMap<>();
+    }
+    public TraitCommand(
+                   @NonNull TypedID issuerID,
+                   @NonNull Map<String, List<Action>> actions) {
+        super(issuerID);
+        if (actions == null || actions.size() == 0) {
+            throw new IllegalArgumentException("actions is null or empty");
+        }
+        this.actions = actions;
+        this.actionResults = new HashMap<>();
+    }
+
+    /**
+     * Add list of ActionResult instance by alias
+     * @param alias Alias name.
+     * @param results List of {@link ActionResult} instances.
+     */
+    public void addActionResults(
+            @NonNull String alias,
+            @NonNull List<ActionResult> results) {
+        this.actionResults.put(alias, results);
+    }
+
+    /**
+     * Get list of actions
+     * @return action of this command.
+     */
+    @NonNull
+    public Map<String, List<Action>> getActions() {
+        return this.actions;
+    }
+
+    /**
+     * Get list of action result
+     * @return action results of this command.
+     */
+    @NonNull
+    public Map<String, List<ActionResult>> getActionResults() {
+        return this.actionResults;
+    }
+
+    /**
+     * Get a action result associated with specified action
+     *
+     * @param alias name of alias to retrieve action result.
+     * @param action action to specify action result.
+     * @return action reuslt specified with parameter's action.
+     */
+    @Nullable
+    public ActionResult getActionResult(
+            @NonNull String alias,
+            @NonNull Action action) {
+        //TODO: implement me
+        return null;
+    }
+
+
+    // Implementation of Parcelable
+    private TraitCommand(Parcel in) {
+        super(in);
+        int size = in.readInt();
+        this.actions = new HashMap<>(size);
+        for(int i= 0; i < size; i++) {
+            String alias = in.readString();
+            List<Action> actions = new ArrayList<>();
+            in.readList(actions, null);
+            this.actions.put(alias, actions);
+        }
+        int size1 = in.readInt();
+        this.actionResults = new HashMap<>(size1);
+        for(int j=0; j < size1; j++) {
+            String alias = in.readString();
+            List<ActionResult> actionResults = new ArrayList<>();
+            in.readList(actionResults, null);
+            this.actionResults.put(alias, actionResults);
+        }
+    }
+    public static final Creator<TraitCommand> CREATOR = new Creator<TraitCommand>() {
+        @Override
+        public TraitCommand createFromParcel(Parcel in) {
+            return new TraitCommand(in);
+        }
+
+        @Override
+        public TraitCommand[] newArray(int size) {
+            return new TraitCommand[size];
+        }
+    };
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        super.writeToParcel(dest, flags);
+        dest.writeInt(this.actions.size());
+        for(Map.Entry<String, List<Action>> e : this.actions.entrySet()){
+            dest.writeString(e.getKey());
+            dest.writeList(e.getValue());
+        }
+        dest.writeInt(this.actionResults.size());
+        for(Map.Entry<String, List<ActionResult>> e : this.actionResults.entrySet()) {
+            dest.writeString(e.getKey());
+            dest.writeList(e.getValue());
+        }
+    }
+}

--- a/thingif/src/main/java/com/kii/thingif/command/TraitCommandForm.java
+++ b/thingif/src/main/java/com/kii/thingif/command/TraitCommandForm.java
@@ -1,0 +1,193 @@
+package com.kii.thingif.command;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.text.TextUtils;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Form of a trait formatted command.
+ *
+ * This class contains data in order to create {@link TraitCommand} with {@link
+ * com.kii.thingif.TraitThingIFAPI#postNewCommand(TraitCommandForm)}.
+ * <br><br>
+ * Mandatory data are followings:
+ * <ul>
+ * <li>List of actions</li>
+ * </ul>
+ * Optional data are followings:
+ * <ul>
+ * <li>Title of a command</li>
+ * <li>Description of a command</li>
+ * <li>meta data of a command</li>
+ * </ul>
+ */
+public final class TraitCommandForm implements Parcelable {
+
+    private final @NonNull
+    Map<String, List<Action>> actions;
+
+    private @Nullable String title;
+    private @Nullable String description;
+    private @Nullable JSONObject metadata;
+
+    /**
+     * Constructs a CommandForm instance.
+     *
+     * @param actions List of actions. Must not be null or empty.
+     * @throws IllegalArgumentException when schemaName is null or empty
+     * string and/or actions is null or empty.
+     */
+    public TraitCommandForm(
+            @NonNull Map<String, List<Action>> actions)
+            throws IllegalArgumentException
+    {
+        if (actions == null || actions.size() == 0) {
+            throw new IllegalArgumentException("actions is null or empty.");
+        }
+        this.actions = actions;
+    }
+
+    /**
+     * Setter of title
+     *
+     * @param title Length of title must be equal or less than 50 characters.
+     * @return this instance
+     * @throws IllegalArgumentException if title is invalid.
+     */
+    public TraitCommandForm setTitle(
+            @Nullable String title)
+            throws IllegalArgumentException
+    {
+        if (title != null && title.length() > 50) {
+            throw new IllegalArgumentException("title is more than 50 charactors.");
+        }
+        this.title = title;
+        return this;
+    }
+
+    /**
+     * Setter of description
+     *
+     * @param description Length of description must be equal or less than
+     * 200 characters.
+     * @return this instance.
+     * @throws IllegalArgumentException if description is invalid.
+     */
+    public TraitCommandForm setDescription(@Nullable String description) {
+        if (description != null && description.length() > 200) {
+            throw new IllegalArgumentException("description is more than 200 charactors.");
+        }
+        this.description = description;
+        return this;
+    }
+
+    /**
+     * Setter of meta data.
+     *
+     * @param metadata meta data of this command.
+     * @return this instance.
+     */
+    public TraitCommandForm setMetadata(@Nullable JSONObject metadata) {
+        this.metadata = metadata;
+        return this;
+    }
+
+
+    /**
+     * Getter of actions.
+     *
+     * @return actions
+     */
+    @NonNull
+    public Map<String, List<Action>> getActions() {
+        return this.actions;
+    }
+
+    /**
+     * Getter of titile.
+     *
+     * @return title
+     */
+    @Nullable
+    public String getTitle() {
+        return this.title;
+    }
+
+    /**
+     * Getter of description.
+     *
+     * @return description
+     */
+    @Nullable
+    public String getDescription() {
+        return this.description;
+    }
+
+    /**
+     * Getter of meta data.
+     *
+     * @return meta data
+     */
+    @Nullable
+    public JSONObject getMetadata() {
+        return this.metadata;
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeInt(this.actions.size());
+        for(Map.Entry<String, List<Action>> e : this.actions.entrySet()) {
+            dest.writeString(e.getKey());
+            dest.writeList(e.getValue());
+        }
+        dest.writeString(this.title);
+        dest.writeString(this.description);
+        dest.writeString(this.metadata == null ? null : this.metadata.toString());
+    }
+
+    public static final Parcelable.Creator<TraitCommandForm> CREATOR
+            = new Parcelable.Creator<TraitCommandForm>() {
+        public TraitCommandForm createFromParcel(Parcel in) {
+            return new TraitCommandForm(in);
+        }
+
+        public TraitCommandForm[] newArray(int size) {
+            return new TraitCommandForm[size];
+        }
+    };
+
+    private TraitCommandForm(Parcel in) {
+        int size = in.readInt();
+        this.actions = new HashMap<>(size);
+        for(int i=0; i < size; i++) {
+            String alias = in.readString();
+            List<Action> actions = new ArrayList<>();
+            in.readList(actions, null);
+        }
+        this.title = in.readString();
+        this.description = in.readString();
+        String metadata = in.readString();
+        if (!TextUtils.isEmpty(metadata)) {
+            try {
+                this.metadata = new JSONObject(metadata);
+            } catch (JSONException ignore) {
+                // Won’t happen
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Add trait version Command: `TraitCommand`
  - Add package private abstract class `AbstractCommand` for common attributes/methods of `Command` and `TraitCommand`
  - Left `List<Action> actions` and `List<ActionResult> actionResults` attributes/methods in `Command`
  - Add `Map<String, List<Action>> actions` and `Map<String, List<ActionResult>> actionResults` in `TraitCommand`

- Add trait version CommandForm: `TraitCommandForm`.
- Add Command relative APIs to `TraitThingIFAPI`.
  - `public TraitCommand postNewCommand( TraitCommandForm)`
  - `public TraitCommand getCommand(String)`
  -  `public Pair<List<TraitCommand>, String>listCommand()`

**Out of scope**
- Build fail on `ThingIFAPI`, since schema and schemaVersion are removed from `Command`. 
