### PR TITLE
Improve alias of command

### DIFF
--- a/thingif/src/main/java/com/kii/thingif/NonTraitAlias.java
+++ b/thingif/src/main/java/com/kii/thingif/NonTraitAlias.java
@@ -4,6 +4,9 @@ import android.os.Parcel;
 
 public final class NonTraitAlias implements Alias {
 
+    public NonTraitAlias() {
+    }
+
     private NonTraitAlias(Parcel in) {
     }
 

--- a/thingif/src/main/java/com/kii/thingif/command/CommandForm.java
+++ b/thingif/src/main/java/com/kii/thingif/command/CommandForm.java
@@ -33,9 +33,9 @@ import java.util.List;
  * <li>meta data of a command</li>
  * </ul>
  */
-public final class CommandForm implements Parcelable {
+public final class CommandForm <T extends Alias> implements Parcelable {
 
-    private final @NonNull List<Pair<Alias,List<Action>>> actions;
+    private final @NonNull List<Pair<T,List<Action>>> actions;
 
     private @Nullable String title;
     private @Nullable String description;
@@ -49,7 +49,7 @@ public final class CommandForm implements Parcelable {
      * string and/or actions is null or empty.
      */
     public CommandForm(
-            @NonNull List<Pair<Alias, List<Action>>> actions)
+            @NonNull List<Pair<T, List<Action>>> actions)
         throws IllegalArgumentException
     {
         if (actions == null || actions.size() == 0) {
@@ -109,7 +109,7 @@ public final class CommandForm implements Parcelable {
      * @return actions
      */
     @NonNull
-    public List<Pair<Alias, List<Action>>> getActions() {
+    public List<Pair<T, List<Action>>> getActions() {
         return this.actions;
     }
 


### PR DESCRIPTION
#### 1. Add generic to CommandForm for `Alias`
Generic is necessary when using `CommandForm` either for `TraitAlais` or `NonTraitAlias`.  If it is not generic, the following snippet will be in compile error: 

```java
        TraitAlias airConditionerAlias = new TraitAlias("AirConditionerAlias");
        List<Action> actions = new ArrayList<>();
        TurnPower turnPower = new TurnPower(true);
        actions.add(turnPower);
        List<Pair<TraitAlias, List<Action>>> traitActions = new ArrayList<>();
        traitActions.add(new Pair<>(airConditionerAlias, actions));
        CommandForm form = new CommandForm(traitActions); // error here. CommandForm only accept alias

```

#### 2. Add constructor for `NonTraitAlias`
`NonTraitAlias` needs a public constructor. 
