### PR TITLE
Improve triggger alias in command and TriggeredCommandForm

### DIFF
--- a/thingif/src/main/java/com/kii/thingif/command/Command.java
+++ b/thingif/src/main/java/com/kii/thingif/command/Command.java
@@ -20,15 +20,15 @@ import java.util.List;
 /**
  * Represents a command that is executed by the thing
  */
-public class Command implements Parcelable {
+public class Command<T extends Alias> implements Parcelable {
 
     private final @Nullable String commandID;
     @SerializedName("target")
     private final @Nullable TypedID targetID;
     @SerializedName("issuer")
     private final @NonNull TypedID issuerID;
-    private final @NonNull List<Pair<? extends Alias, List<Action>>> actions;
-    private final @Nullable List<Pair<? extends Alias,List<ActionResult>>> actionResults;
+    private final @NonNull List<Pair<T, List<Action>>> actions;
+    private final @Nullable List<Pair<T,List<ActionResult>>> actionResults;
     @SerializedName("commandState")
     private final @Nullable CommandState commandState;
     private final @Nullable String firedByTriggerID;
@@ -42,8 +42,8 @@ public class Command implements Parcelable {
 
     public Command(@NonNull TypedID targetID,
                    @NonNull TypedID issuerID,
-                   @NonNull List<Pair<? extends Alias, List<Action>>> actions,
-                   @Nullable List<Pair<? extends Alias,List<ActionResult>>> actonResults,
+                   @NonNull List<Pair<T, List<Action>>> actions,
+                   @Nullable List<Pair<T,List<ActionResult>>> actonResults,
                    @Nullable String commandID,
                    @Nullable CommandState commandState,
                    @Nullable String firedByTriggerID,
@@ -107,7 +107,7 @@ public class Command implements Parcelable {
      * @return action of this command.
      */
     @NonNull
-    public List<Pair<? extends Alias, List<Action>>> getActions() {
+    public List<Pair<T, List<Action>>> getActions() {
         return this.actions;
     }
 
@@ -116,7 +116,7 @@ public class Command implements Parcelable {
      * @return action results of this command.
      */
     @Nullable
-    public List<Pair<? extends Alias,List<ActionResult>>> getActionResults() {
+    public List<Pair<T,List<ActionResult>>> getActionResults() {
         return this.actionResults;
     }
 

--- a/thingif/src/main/java/com/kii/thingif/command/Command.java
+++ b/thingif/src/main/java/com/kii/thingif/command/Command.java
@@ -27,8 +27,8 @@ public class Command implements Parcelable {
     private final @Nullable TypedID targetID;
     @SerializedName("issuer")
     private final @NonNull TypedID issuerID;
-    private final @NonNull List<Pair<Alias, List<Action>>> actions;
-    private final @Nullable List<Pair<Alias,List<ActionResult>>> actionResults;
+    private final @NonNull List<Pair<? extends Alias, List<Action>>> actions;
+    private final @Nullable List<Pair<? extends Alias,List<ActionResult>>> actionResults;
     @SerializedName("commandState")
     private final @Nullable CommandState commandState;
     private final @Nullable String firedByTriggerID;
@@ -42,8 +42,8 @@ public class Command implements Parcelable {
 
     public Command(@NonNull TypedID targetID,
                    @NonNull TypedID issuerID,
-                   @NonNull List<Pair<Alias, List<Action>>> actions,
-                   @Nullable List<Pair<Alias,List<ActionResult>>> actonResults,
+                   @NonNull List<Pair<? extends Alias, List<Action>>> actions,
+                   @Nullable List<Pair<? extends Alias,List<ActionResult>>> actonResults,
                    @Nullable String commandID,
                    @Nullable CommandState commandState,
                    @Nullable String firedByTriggerID,
@@ -107,7 +107,7 @@ public class Command implements Parcelable {
      * @return action of this command.
      */
     @NonNull
-    public List<Pair<Alias, List<Action>>> getActions() {
+    public List<Pair<? extends Alias, List<Action>>> getActions() {
         return this.actions;
     }
 
@@ -116,7 +116,7 @@ public class Command implements Parcelable {
      * @return action results of this command.
      */
     @Nullable
-    public List<Pair<Alias,List<ActionResult>>> getActionResults() {
+    public List<Pair<? extends Alias,List<ActionResult>>> getActionResults() {
         return this.actionResults;
     }
 
@@ -209,9 +209,10 @@ public class Command implements Parcelable {
         this.commandID = in.readString();
         this.targetID = in.readParcelable(TypedID.class.getClassLoader());
         this.issuerID = in.readParcelable(TypedID.class.getClassLoader());
-        this.actions = new ArrayList<Pair<Alias, List<Action>>>();
+        //TODO: // FIXME: 12/16/16 fix to adapt to alias
+        this.actions = new ArrayList<>();
         in.readList(this.actions, Command.class.getClassLoader());
-        this.actionResults = new ArrayList<Pair<Alias, List<ActionResult>>>();
+        this.actionResults = new ArrayList<>();
         in.readList(this.actionResults, Command.class.getClassLoader());
         this.commandState = (CommandState)in.readSerializable();
         this.firedByTriggerID = in.readString();
@@ -250,6 +251,7 @@ public class Command implements Parcelable {
         dest.writeString(this.commandID);
         dest.writeParcelable(this.targetID, flags);
         dest.writeParcelable(this.issuerID, flags);
+        //TODO // FIXME: 12/16/16 fix to adapt alias
         dest.writeList(this.actions);
         dest.writeList(this.actionResults);
         dest.writeSerializable(this.commandState);

--- a/thingif/src/main/java/com/kii/thingif/trigger/TriggeredCommandForm.java
+++ b/thingif/src/main/java/com/kii/thingif/trigger/TriggeredCommandForm.java
@@ -41,21 +41,21 @@ import java.util.List;
  * <li>meta data of a command</li>
  * </ul>
  */
-public class TriggeredCommandForm implements Parcelable {
+public class TriggeredCommandForm<T extends Alias> implements Parcelable {
 
     /**
      * TriggeredCommandForm builder.
      */
-    public static class Builder {
+    public static class Builder<T1 extends Alias> {
 
-        @NonNull private List<Pair<? extends Alias, List<Action>>> actions;
+        @NonNull private List<Pair<T1, List<Action>>> actions;
         @Nullable private TypedID targetID;
         @Nullable private String title;
         @Nullable private String description;
         @Nullable private JSONObject metadata;
 
         private Builder(
-                @NonNull List<Pair<? extends Alias, List<Action>>> actions)
+                @NonNull List<Pair<T1, List<Action>>> actions)
         {
             if (isEmpty(actions)) {
                 throw new IllegalArgumentException("actions is null or empty.");
@@ -70,30 +70,15 @@ public class TriggeredCommandForm implements Parcelable {
          * @throws IllegalArgumentException This exception is thrown if one or
          * more following conditions are met.
          * <ul>
-         *   <li>schemaName is null or empty string.</li>
          *   <li>actions is null or empty</li>
          * </ul>
          * @return builder instance.
          */
         @NonNull
-        public static Builder newBuilder(
-                @NonNull List<Pair<TraitAlias, List<Action>>> actions)
+        public static <T2 extends Alias>Builder<T2> newBuilder(
+                @NonNull List<Pair<T2, List<Action>>> actions)
         {
-            List<Pair<? extends Alias, List<Action>>> traitActions = new ArrayList<>();
-            for (Pair<TraitAlias, List<Action>> aTraitActions: actions){
-                traitActions.add(aTraitActions);
-            }
-            return new Builder(traitActions);
-        }
-
-        public static Builder newNonTraitBuilder(
-                @NonNull List<Pair<NonTraitAlias, List<Action>>> actions)
-        {
-            List<Pair<? extends Alias, List<Action>>> nonTraitActions = new ArrayList<>();
-            for (Pair<NonTraitAlias, List<Action>> aTraitActions: actions){
-                nonTraitActions.add(aTraitActions);
-            }
-            return new Builder(nonTraitActions);
+            return new Builder<>(actions);
         }
 
         /**
@@ -117,12 +102,11 @@ public class TriggeredCommandForm implements Parcelable {
          * @throws IllegalArgumentException if command is null.
          */
         @NonNull
-        public static Builder newBuilderFromCommand(
-                @NonNull Command command)
+        public static <T3 extends Alias> Builder<T3> newBuilderFromCommand(
+                @NonNull Command<T3> command)
             throws IllegalArgumentException
         {
-            return (new Builder(
-                        command.getActions())).
+            return (new Builder<>(command.getActions())).
                     setTargetID(command.getTargetID()).
                     setTitle(command.getTitle()).
                     setDescription(command.getDescription()).
@@ -142,8 +126,8 @@ public class TriggeredCommandForm implements Parcelable {
          * @throws IllegalArgumentException actions is null or empty list.
          */
         @NonNull
-        public Builder setActions(
-                @NonNull List<Pair<? extends Alias, List<Action>>> actions)
+        public Builder<T1> setActions(
+                @NonNull List<Pair<T1, List<Action>>> actions)
             throws IllegalArgumentException
         {
             if (isEmpty(actions)) {
@@ -159,7 +143,7 @@ public class TriggeredCommandForm implements Parcelable {
          * @return actions
          */
         @NonNull
-        public List<Pair<? extends Alias, List<Action>>> getActions() {
+        public List<Pair<T1, List<Action>>> getActions() {
             return this.actions;
         }
 
@@ -191,7 +175,7 @@ public class TriggeredCommandForm implements Parcelable {
          * TypedID.Types#THING}.
          */
         @NonNull
-        public Builder setTargetID(
+        public Builder<T1> setTargetID(
                 @Nullable TypedID targetID)
             throws IllegalArgumentException
         {
@@ -222,7 +206,7 @@ public class TriggeredCommandForm implements Parcelable {
          * @throws IllegalArgumentException if title is invalid.
          */
         @NonNull
-        public Builder setTitle(
+        public Builder<T1> setTitle(
                 @Nullable String title)
             throws IllegalArgumentException
         {
@@ -253,7 +237,7 @@ public class TriggeredCommandForm implements Parcelable {
          * @throws IllegalArgumentException if description is invalid.
          */
         @NonNull
-        public Builder setDescription(
+        public Builder<T1> setDescription(
                 @Nullable String description)
             throws IllegalArgumentException
         {
@@ -282,7 +266,7 @@ public class TriggeredCommandForm implements Parcelable {
          * @return this instance for method chaining.
          */
         @NonNull
-        public Builder setMetadata(@Nullable JSONObject metadata) {
+        public Builder<T1> setMetadata(@Nullable JSONObject metadata) {
             this.metadata = metadata;
             return this;
         }
@@ -303,9 +287,10 @@ public class TriggeredCommandForm implements Parcelable {
          * @return {@link TriggeredCommandForm} instance.
          */
         @NonNull
-        public TriggeredCommandForm build() {
-            TriggeredCommandForm retval =
-                    new TriggeredCommandForm(this.actions);
+        public TriggeredCommandForm<T1> build() {
+
+            TriggeredCommandForm<T1> retval =
+                    new TriggeredCommandForm<T1>(this.actions);
             retval.targetID = this.targetID;
             retval.title = this.title;
             retval.description = this.description;
@@ -325,7 +310,7 @@ public class TriggeredCommandForm implements Parcelable {
 
     }
 
-    @NonNull private final List<Pair<? extends Alias, List<Action>>> actions;
+    @NonNull private final List<Pair<T, List<Action>>> actions;
     @SerializedName("target")
     @Nullable private TypedID targetID;
     @Nullable private String title;
@@ -333,7 +318,7 @@ public class TriggeredCommandForm implements Parcelable {
     @Nullable private JSONObject metadata;
 
     private TriggeredCommandForm(
-            @NonNull List<Pair<? extends Alias, List<Action>>> actions)
+            @NonNull List<Pair<T, List<Action>>> actions)
     {
         this.actions = actions;
     }
@@ -344,7 +329,7 @@ public class TriggeredCommandForm implements Parcelable {
      * @return actions
      */
     @NonNull
-    public List<Pair<? extends Alias, List<Action>>> getActions() {
+    public List<Pair<T, List<Action>>> getActions() {
         return this.actions;
     }
 
@@ -389,6 +374,7 @@ public class TriggeredCommandForm implements Parcelable {
     }
 
     private TriggeredCommandForm(Parcel in) {
+        //TODO: // FIXME: 12/16/16 should adapt to alias subclasses
         this.actions = new ArrayList<>();
         in.readList(this.actions, TriggeredCommandForm.class.getClassLoader());
         this.targetID = in.readParcelable(TypedID.class.getClassLoader());
@@ -406,6 +392,7 @@ public class TriggeredCommandForm implements Parcelable {
 
     @Override
     public void writeToParcel(Parcel dest, int flags) {
+        //TODO: // FIXME: 12/16/16 should adapt to alias subclass
         dest.writeList(this.actions);
         dest.writeParcelable(this.getTargetID(), flags);
         dest.writeString(this.title);

--- a/thingif/src/main/java/com/kii/thingif/trigger/TriggeredCommandForm.java
+++ b/thingif/src/main/java/com/kii/thingif/trigger/TriggeredCommandForm.java
@@ -9,6 +9,8 @@ import android.util.Pair;
 
 import com.google.gson.annotations.SerializedName;
 import com.kii.thingif.Alias;
+import com.kii.thingif.NonTraitAlias;
+import com.kii.thingif.TraitAlias;
 import com.kii.thingif.TypedID;
 import com.kii.thingif.command.Action;
 import com.kii.thingif.command.Command;
@@ -46,14 +48,14 @@ public class TriggeredCommandForm implements Parcelable {
      */
     public static class Builder {
 
-        @NonNull private List<Pair<Alias, List<Action>>> actions;
+        @NonNull private List<Pair<? extends Alias, List<Action>>> actions;
         @Nullable private TypedID targetID;
         @Nullable private String title;
         @Nullable private String description;
         @Nullable private JSONObject metadata;
 
         private Builder(
-                @NonNull List<Pair<Alias, List<Action>>> actions)
+                @NonNull List<Pair<? extends Alias, List<Action>>> actions)
         {
             if (isEmpty(actions)) {
                 throw new IllegalArgumentException("actions is null or empty.");
@@ -75,10 +77,23 @@ public class TriggeredCommandForm implements Parcelable {
          */
         @NonNull
         public static Builder newBuilder(
-                @NonNull List<Pair<Alias, List<Action>>> actions)
-            throws IllegalArgumentException
+                @NonNull List<Pair<TraitAlias, List<Action>>> actions)
         {
-            return new Builder(actions);
+            List<Pair<? extends Alias, List<Action>>> traitActions = new ArrayList<>();
+            for (Pair<TraitAlias, List<Action>> aTraitActions: actions){
+                traitActions.add(aTraitActions);
+            }
+            return new Builder(traitActions);
+        }
+
+        public static Builder newNonTraitBuilder(
+                @NonNull List<Pair<NonTraitAlias, List<Action>>> actions)
+        {
+            List<Pair<? extends Alias, List<Action>>> nonTraitActions = new ArrayList<>();
+            for (Pair<NonTraitAlias, List<Action>> aTraitActions: actions){
+                nonTraitActions.add(aTraitActions);
+            }
+            return new Builder(nonTraitActions);
         }
 
         /**
@@ -89,8 +104,6 @@ public class TriggeredCommandForm implements Parcelable {
          * </p>
          *
          * <ul>
-         *   <li>{@link Command#getSchemaName()}</li>
-         *   <li>{@link Command#getSchemaVersion()}</li>
          *   <li>{@link Command#getActions()}</li>
          *   <li>{@link Command#getTargetID()}</li>
          *   <li>{@link Command#getTitle()}</li>
@@ -130,7 +143,7 @@ public class TriggeredCommandForm implements Parcelable {
          */
         @NonNull
         public Builder setActions(
-                @NonNull List<Pair<Alias, List<Action>>> actions)
+                @NonNull List<Pair<? extends Alias, List<Action>>> actions)
             throws IllegalArgumentException
         {
             if (isEmpty(actions)) {
@@ -146,7 +159,7 @@ public class TriggeredCommandForm implements Parcelable {
          * @return actions
          */
         @NonNull
-        public List<Pair<Alias, List<Action>>> getActions() {
+        public List<Pair<? extends Alias, List<Action>>> getActions() {
             return this.actions;
         }
 
@@ -312,7 +325,7 @@ public class TriggeredCommandForm implements Parcelable {
 
     }
 
-    @NonNull private final List<Pair<Alias, List<Action>>> actions;
+    @NonNull private final List<Pair<? extends Alias, List<Action>>> actions;
     @SerializedName("target")
     @Nullable private TypedID targetID;
     @Nullable private String title;
@@ -320,7 +333,7 @@ public class TriggeredCommandForm implements Parcelable {
     @Nullable private JSONObject metadata;
 
     private TriggeredCommandForm(
-            @NonNull List<Pair<Alias, List<Action>>> actions)
+            @NonNull List<Pair<? extends Alias, List<Action>>> actions)
     {
         this.actions = actions;
     }
@@ -331,7 +344,7 @@ public class TriggeredCommandForm implements Parcelable {
      * @return actions
      */
     @NonNull
-    public List<Pair<Alias, List<Action>>> getActions() {
+    public List<Pair<? extends Alias, List<Action>>> getActions() {
         return this.actions;
     }
 


### PR DESCRIPTION
- Make `Command` and `TriggerredCommandForm` generic

**Note**: Clause and condition will be improve in another PR. 

Snippet to create trigger will be like this: 

```java
        List<Action> actions = new ArrayList<>();
        actions.add(new SetPresetTemperature(25));

        Alias alias;

        // Trait formatted trigger
        TraitAlias airConditionerAlias = new TraitAlias("AirConditionerAlias");
        List<Pair<TraitAlias, List<Action>>> traitActions = new ArrayList<>();
        traitActions.add(new Pair<>(airConditionerAlias, actions));

        TriggeredCommandForm<TraitAlias> triggerForm = TriggeredCommandForm
                .Builder
                .newBuilder(traitActions)
                .build();

        // Non trait formatted trigger
        NonTraitAlias nonTraitAlias = new NonTraitAlias();
        List<Pair<NonTraitAlias, List<Action>>> nonTraitActions = new ArrayList<>();
        nonTraitActions.add(new Pair<>(nonTraitAlias, actions));

        TriggeredCommandForm<NonTraitAlias> triggerForm2 = TriggeredCommandForm
                .Builder
                .newBuilder(nonTraitActions)
                .build();
```