### PR TITLE
Make Condition, Clause and StatePredicate generic

### DIFF
--- a/thingif/src/main/java/com/kii/thingif/trigger/Condition.java
+++ b/thingif/src/main/java/com/kii/thingif/trigger/Condition.java
@@ -4,14 +4,15 @@ import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
 
+import com.kii.thingif.Alias;
 import com.kii.thingif.trigger.clause.Clause;
 
-public class Condition implements Parcelable {
-    private Clause clause;
-    public Condition(@NonNull Clause clause) {
+public class Condition<T extends Alias> implements Parcelable {
+    private Clause<T> clause;
+    public Condition(@NonNull Clause<T> clause) {
         this.clause = clause;
     }
-    public Clause getClause() {
+    public Clause<T> getClause() {
         return this.clause;
     }
 

--- a/thingif/src/main/java/com/kii/thingif/trigger/StatePredicate.java
+++ b/thingif/src/main/java/com/kii/thingif/trigger/StatePredicate.java
@@ -3,12 +3,14 @@ package com.kii.thingif.trigger;
 import android.os.Parcel;
 import android.support.annotation.NonNull;
 
-public class StatePredicate extends Predicate {
+import com.kii.thingif.Alias;
 
-    private Condition condition;
+public class StatePredicate<T extends Alias> extends Predicate {
+
+    private Condition<T> condition;
     private TriggersWhen triggersWhen;
 
-    public StatePredicate(@NonNull Condition condition, @NonNull TriggersWhen triggersWhen) {
+    public StatePredicate(@NonNull Condition<T> condition, @NonNull TriggersWhen triggersWhen) {
         if (condition == null) {
             throw new IllegalArgumentException("condition is null");
         }

--- a/thingif/src/main/java/com/kii/thingif/trigger/clause/And.java
+++ b/thingif/src/main/java/com/kii/thingif/trigger/clause/And.java
@@ -2,14 +2,16 @@ package com.kii.thingif.trigger.clause;
 
 import android.os.Parcel;
 
+import com.kii.thingif.Alias;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.Arrays;
 
-public class And extends ContainerClause {
-    public And(Clause... clauses) {
+public class And<T extends Alias> extends ContainerClause<T> {
+    public And(Clause<T>... clauses) {
         super(clauses);
     }
     @Override

--- a/thingif/src/main/java/com/kii/thingif/trigger/clause/Clause.java
+++ b/thingif/src/main/java/com/kii/thingif/trigger/clause/Clause.java
@@ -2,9 +2,11 @@ package com.kii.thingif.trigger.clause;
 
 import android.os.Parcelable;
 
+import com.kii.thingif.Alias;
+
 import org.json.JSONObject;
 
-public abstract class Clause implements Parcelable {
+public abstract class Clause<T extends Alias> implements Parcelable {
 
     public abstract JSONObject toJSONObject();
 

--- a/thingif/src/main/java/com/kii/thingif/trigger/clause/ContainerClause.java
+++ b/thingif/src/main/java/com/kii/thingif/trigger/clause/ContainerClause.java
@@ -1,13 +1,15 @@
 package com.kii.thingif.trigger.clause;
 
+import com.kii.thingif.Alias;
+
 import java.util.ArrayList;
 import java.util.List;
 
-public abstract class ContainerClause extends Clause {
-    protected final List<Clause> clauses = new ArrayList<Clause>();
-    public ContainerClause(Clause... clauses) {
+public abstract class ContainerClause<T extends Alias> extends Clause<T> {
+    protected final List<Clause<T>> clauses = new ArrayList<>();
+    public ContainerClause(Clause<T>... clauses) {
         if (clauses != null) {
-            for (Clause clause : clauses) {
+            for (Clause<T> clause : clauses) {
                 this.clauses.add(clause);
             }
         }
@@ -15,7 +17,7 @@ public abstract class ContainerClause extends Clause {
     public Clause[] getClauses() {
         return this.clauses.toArray(new Clause[this.clauses.size()]);
     }
-    public void addClause(Clause clause) {
+    public void addClause(Clause<T> clause) {
         this.clauses.add(clause);
     }
     public boolean hasClause() {

--- a/thingif/src/main/java/com/kii/thingif/trigger/clause/Equals.java
+++ b/thingif/src/main/java/com/kii/thingif/trigger/clause/Equals.java
@@ -1,28 +1,35 @@
 package com.kii.thingif.trigger.clause;
 
 import android.os.Parcel;
+import android.provider.AlarmClock;
 import android.support.annotation.NonNull;
+
+import com.kii.thingif.Alias;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
-public class Equals extends Clause {
+public class Equals<T extends Alias> extends Clause<T> {
 
     private final String field;
     private final Object value;
-    public Equals(@NonNull String field, String value) {
+    private final T alias;
+    public Equals(@NonNull String field, String value, T alias) {
         this.field = field;
         this.value = value;
+        this.alias = alias;
     }
 
-    public Equals(String field, long value) {
+    public Equals(String field, long value, T alias) {
         this.field = field;
         this.value = value;
+        this.alias = alias;
     }
 
-    public Equals(String field, boolean value) {
+    public Equals(String field, boolean value, T alias) {
         this.field = field;
         this.value = value;
+        this.alias = alias;
     }
     public String getField() {
         return this.field;
@@ -33,6 +40,7 @@ public class Equals extends Clause {
 
     @Override
     public JSONObject toJSONObject() {
+        //TODO: // FIXME: 12/15/16 should adapt to alias
         JSONObject ret = new JSONObject();
         try {
             ret.put("type", "eq");
@@ -47,6 +55,7 @@ public class Equals extends Clause {
 
     @Override
     public boolean equals(Object o) {
+        //TODO: // FIXME: 12/15/16 should adapt to alias
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Equals equals = (Equals) o;
@@ -62,6 +71,8 @@ public class Equals extends Clause {
 
     // Implementation of Parcelable
     protected Equals(Parcel in) {
+        //TODO: // FIXME: 12/15/16 should adapt to subclass of Alias, refer http://stackoverflow.com/a/31979348
+        this.alias = in.readParcelable(Alias.class.getClassLoader());
         this.field = in.readString();
         Class<?> clazz = (Class<?>)in.readSerializable();
         if (clazz == String.class) {
@@ -91,6 +102,7 @@ public class Equals extends Clause {
     }
     @Override
     public void writeToParcel(Parcel dest, int flags) {
+        //TODO: // FIXME: 12/15/16 shoudl adapt to subclass of Alias
         dest.writeString(this.field);
         dest.writeSerializable(this.value.getClass());
         if (this.value instanceof String) {

--- a/thingif/src/main/java/com/kii/thingif/trigger/clause/NotEquals.java
+++ b/thingif/src/main/java/com/kii/thingif/trigger/clause/NotEquals.java
@@ -3,12 +3,14 @@ package com.kii.thingif.trigger.clause;
 import android.os.Parcel;
 import android.support.annotation.NonNull;
 
+import com.kii.thingif.Alias;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
-public class NotEquals extends Clause {
-    private final Equals equals;
-    public NotEquals(@NonNull Equals equals) {
+public class NotEquals<T extends Alias> extends Clause {
+    private final Equals<T> equals;
+    public NotEquals(@NonNull Equals<T> equals) {
         this.equals = equals;
     }
     @Override

--- a/thingif/src/main/java/com/kii/thingif/trigger/clause/Or.java
+++ b/thingif/src/main/java/com/kii/thingif/trigger/clause/Or.java
@@ -2,14 +2,16 @@ package com.kii.thingif.trigger.clause;
 
 import android.os.Parcel;
 
+import com.kii.thingif.Alias;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.Arrays;
 
-public class Or extends ContainerClause {
-    public Or(Clause... clauses) {
+public class Or<T extends Alias> extends ContainerClause<T> {
+    public Or(Clause<T>... clauses) {
         super(clauses);
     }
     @Override

--- a/thingif/src/main/java/com/kii/thingif/trigger/clause/Range.java
+++ b/thingif/src/main/java/com/kii/thingif/trigger/clause/Range.java
@@ -3,51 +3,65 @@ package com.kii.thingif.trigger.clause;
 import android.os.Parcel;
 import android.support.annotation.NonNull;
 
+import com.kii.thingif.Alias;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 
-public class Range extends Clause {
+public class Range<T extends Alias> extends Clause<T> {
 
     private final String field;
     private final Long upperLimit;
     private final Long lowerLimit;
     private final Boolean upperIncluded;
     private final Boolean lowerIncluded;
+    private final T alias;
 
-    public Range(String field, Long upperLimit, Boolean upperIncluded, Long lowerLimit, Boolean lowerIncluded) {
+    public Range(String field, 
+                 Long upperLimit,
+                 Boolean upperIncluded, 
+                 Long lowerLimit, 
+                 Boolean lowerIncluded, 
+                 T alias) {
         this.field = field;
         this.upperLimit = upperLimit;
         this.upperIncluded = upperIncluded;
         this.lowerLimit = lowerLimit;
         this.lowerIncluded = lowerIncluded;
+        this.alias = alias;
     }
-    public static Range range(
+    public static <T1 extends Alias> Range range(
             @NonNull String field,
             Number upperLimit,
             Boolean upperIncluded,
             Number lowerLimit,
-            Boolean lowerIncluded) {
-        return new Range(field, upperLimit.longValue(), upperIncluded, lowerLimit.longValue(), lowerIncluded);
+            Boolean lowerIncluded, 
+            T1 alias) {
+        return new Range<>(field, upperLimit.longValue(), upperIncluded, lowerLimit.longValue(), lowerIncluded, alias);
     }
-    public static Range greaterThan(
+    public static <T2 extends Alias> Range<T2> greaterThan(
             @NonNull String field,
-            @NonNull Number lowerLimit) {
-        return new Range(field, null, null, lowerLimit.longValue(), Boolean.FALSE);
+            @NonNull Number lowerLimit,
+            @NonNull T2 alias) {
+        return new Range<>(field, null, null, lowerLimit.longValue(), Boolean.FALSE, alias);
     }
-    public static Range greaterThanEquals(
+    public static <T3 extends Alias> Range<T3> greaterThanEquals(
             @NonNull String field,
-            @NonNull Number lowerLimit) {
-        return new Range(field, null, null, lowerLimit.longValue(), Boolean.TRUE);
+            @NonNull Number lowerLimit,
+            @NonNull T3 alias) {
+        return new Range<>(field, null, null, lowerLimit.longValue(), Boolean.TRUE, alias);
     }
-    public static Range lessThan(
+    public static <T4 extends Alias> Range<T4> lessThan(
             @NonNull String field,
-            @NonNull Number upperLimit) {
-        return new Range(field, upperLimit.longValue(), Boolean.FALSE, null, null);
+            @NonNull Number upperLimit,
+            @NonNull T4 alias) {
+        return new Range<>(field, upperLimit.longValue(), Boolean.FALSE, null, null, alias);
     }
-    public static Range lessThanEquals(
+    public static <T5 extends  Alias> Range<T5> lessThanEquals(
             @NonNull String field,
-            @NonNull Number upperLimit) {
-        return new Range(field, upperLimit.longValue(), Boolean.TRUE, null, null);
+            @NonNull Number upperLimit,
+            @NonNull T5 alias) {
+        return new Range<>(field, upperLimit.longValue(), Boolean.TRUE, null, null, alias);
     }
 
     public String getField() {
@@ -65,10 +79,14 @@ public class Range extends Clause {
     public Boolean getLowerIncluded() {
         return this.lowerIncluded;
     }
+    public Alias getAlias() {
+        return alias;
+    }
 
     @Override
     public JSONObject toJSONObject() {
         JSONObject ret = new JSONObject();
+        //TODO: // FIXME: 12/15/16 should adapt to alias
         try {
             ret.put("type", "range");
             ret.put("field", this.field);
@@ -93,6 +111,7 @@ public class Range extends Clause {
 
     @Override
     public boolean equals(Object o) {
+        //TODO: // FIXME: 12/15/16 should adapt to alias
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
 
@@ -119,6 +138,8 @@ public class Range extends Clause {
 
     // Implementation of Parcelable
     protected Range(Parcel in) {
+        //TODO: // FIXME: 12/15/16 should adapt to alias
+        this.alias = in.readParcelable(Alias.class.getClassLoader());
         this.field = in.readString();
         this.upperLimit = (Long)in.readValue(Range.class.getClassLoader());
         this.upperIncluded = (Boolean)in.readValue(Range.class.getClassLoader());
@@ -142,6 +163,7 @@ public class Range extends Clause {
     }
     @Override
     public void writeToParcel(Parcel dest, int flags) {
+        //TODO: // FIXME: 12/15/16 shuold adapt to alias
         dest.writeString(this.field);
         dest.writeValue(this.upperLimit);
         dest.writeValue(this.upperIncluded);


### PR DESCRIPTION
### Generic the following classes
- StatePredicate
- Condition
- Clause
- ContainerClause
- And
- Or
- Equals
- NotEquals
- Range

The snippets to use generic for predate like this:

```java
        // TraitAlias 
        TraitAlias airConditionerAlias = new TraitAlias("AirConditionerAlias");
        Clause<TraitAlias> clause1  = new Equals<>("power", true, airConditionerAlias);
        Clause<TraitAlias> clause2 = Range.greaterThan("currentTemperature", 28, airConditionerAlias);
        Condition<TraitAlias> condition = new Condition<>(new And<>(clause1, clause2));
        Predicate statePredicate = new StatePredicate<>(condition, TriggersWhen.CONDITION_FALSE_TO_TRUE);

       // Non trait
        NonTraitAlias nonTraitAlias = new NonTraitAlias();
        Clause<NonTraitAlias> clause3 = new Equals<>("power", true, nonTraitAlias);
        Clause<NonTraitAlias> clause4 = Range.greaterThan("currentTemperature", 28, nonTraitAlias);
        Condition<NonTraitAlias> condition1 = new Condition<>(new And<>(clause3, clause4));
        Predicate statePredicate = new StatePredicate<>(condition1, TriggersWhen.CONDITION_FALSE_TO_TRUE);

```
