### PR TITLE
Generic ThingIFAPI and ThingIFAPIBuilder

### DIFF
--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -51,7 +51,7 @@ import java.util.Map;
 /**
  * This class operates an IoT device that is specified by {@link #onboard(String, String, String, JSONObject)} method.
  */
-public class ThingIFAPI implements Parcelable {
+public class ThingIFAPI<AliasType extends Alias> implements Parcelable {
 
     private static final String SHARED_PREFERENCES_KEY_INSTANCE = "ThingIFAPI_INSTANCE";
     private static final String SHARED_PREFERENCES_SDK_VERSION_KEY = "ThingIFAPI_VERSION";
@@ -661,7 +661,7 @@ public class ThingIFAPI implements Parcelable {
     @NonNull
     @WorkerThread
     public Command postNewCommand(
-            @NonNull CommandForm form) throws ThingIFException {
+            @NonNull CommandForm<AliasType> form) throws ThingIFException {
         if (this.target == null) {
             throw new IllegalStateException("Can not perform this action before onboarding");
         }
@@ -715,6 +715,7 @@ public class ThingIFAPI implements Parcelable {
         if (schema == null) {
             throw new UnsupportedSchemaException(schemaName, schemaVersion);
         }
+        //TODO: // FIXME: 12/16/16
         return this.deserialize(schema, responseBody, Command.class);
     }
     /**
@@ -805,7 +806,7 @@ public class ThingIFAPI implements Parcelable {
     @NonNull
     @WorkerThread
     public Trigger postNewTrigger(
-            @NonNull TriggeredCommandForm form,
+            @NonNull TriggeredCommandForm<AliasType> form,
             @NonNull Predicate predicate,
             @Nullable TriggerOptions options)
         throws ThingIFException
@@ -814,7 +815,7 @@ public class ThingIFAPI implements Parcelable {
     }
 
     private Trigger postNewTriggerWithForm(
-            @NonNull TriggeredCommandForm form,
+            @NonNull TriggeredCommandForm<AliasType> form,
             @NonNull Predicate predicate,
             @Nullable TriggerOptions options)
         throws ThingIFException
@@ -1003,7 +1004,7 @@ public class ThingIFAPI implements Parcelable {
     @WorkerThread
     public Trigger patchTrigger(
             @NonNull String triggerID,
-            @Nullable TriggeredCommandForm form,
+            @Nullable TriggeredCommandForm<AliasType> form,
             @Nullable Predicate predicate,
             @Nullable TriggerOptions options)
         throws ThingIFException
@@ -1015,7 +1016,7 @@ public class ThingIFAPI implements Parcelable {
     @WorkerThread
     private Trigger patchTriggerWithForm(
             @NonNull String triggerID,
-            @Nullable TriggeredCommandForm form,
+            @Nullable TriggeredCommandForm<AliasType> form,
             @Nullable Predicate predicate,
             @Nullable TriggerOptions options)
         throws ThingIFException

--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -51,7 +51,7 @@ import java.util.Map;
 /**
  * This class operates an IoT device that is specified by {@link #onboard(String, String, String, JSONObject)} method.
  */
-public class ThingIFAPI<AliasType extends Alias> implements Parcelable {
+public class ThingIFAPI<T extends Alias> implements Parcelable {
 
     private static final String SHARED_PREFERENCES_KEY_INSTANCE = "ThingIFAPI_INSTANCE";
     private static final String SHARED_PREFERENCES_SDK_VERSION_KEY = "ThingIFAPI_VERSION";
@@ -661,7 +661,7 @@ public class ThingIFAPI<AliasType extends Alias> implements Parcelable {
     @NonNull
     @WorkerThread
     public Command postNewCommand(
-            @NonNull CommandForm<AliasType> form) throws ThingIFException {
+            @NonNull CommandForm<T> form) throws ThingIFException {
         if (this.target == null) {
             throw new IllegalStateException("Can not perform this action before onboarding");
         }
@@ -806,7 +806,7 @@ public class ThingIFAPI<AliasType extends Alias> implements Parcelable {
     @NonNull
     @WorkerThread
     public Trigger postNewTrigger(
-            @NonNull TriggeredCommandForm<AliasType> form,
+            @NonNull TriggeredCommandForm<T> form,
             @NonNull Predicate predicate,
             @Nullable TriggerOptions options)
         throws ThingIFException
@@ -815,7 +815,7 @@ public class ThingIFAPI<AliasType extends Alias> implements Parcelable {
     }
 
     private Trigger postNewTriggerWithForm(
-            @NonNull TriggeredCommandForm<AliasType> form,
+            @NonNull TriggeredCommandForm<T> form,
             @NonNull Predicate predicate,
             @Nullable TriggerOptions options)
         throws ThingIFException
@@ -1004,7 +1004,7 @@ public class ThingIFAPI<AliasType extends Alias> implements Parcelable {
     @WorkerThread
     public Trigger patchTrigger(
             @NonNull String triggerID,
-            @Nullable TriggeredCommandForm<AliasType> form,
+            @Nullable TriggeredCommandForm<T> form,
             @Nullable Predicate predicate,
             @Nullable TriggerOptions options)
         throws ThingIFException
@@ -1016,7 +1016,7 @@ public class ThingIFAPI<AliasType extends Alias> implements Parcelable {
     @WorkerThread
     private Trigger patchTriggerWithForm(
             @NonNull String triggerID,
-            @Nullable TriggeredCommandForm<AliasType> form,
+            @Nullable TriggeredCommandForm<T> form,
             @Nullable Predicate predicate,
             @Nullable TriggerOptions options)
         throws ThingIFException

--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPIBuilder.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPIBuilder.java
@@ -11,7 +11,7 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.List;
 
-public class ThingIFAPIBuilder {
+public class ThingIFAPIBuilder<T extends Alias> {
 
     private static final String TAG = ThingIFAPIBuilder.class.getSimpleName();
     private final Context context;
@@ -38,7 +38,7 @@ public class ThingIFAPIBuilder {
      * @return ThingIFAPIBuilder instance.
      */
     @NonNull
-    public static ThingIFAPIBuilder newBuilder(
+    public static <T1 extends Alias>  ThingIFAPIBuilder<T1> newBuilder(
             @NonNull Context context,
             @NonNull KiiApp app,
             @NonNull Owner owner) {
@@ -51,7 +51,7 @@ public class ThingIFAPIBuilder {
         if (owner == null) {
             throw new IllegalArgumentException("owner is null");
         }
-        return new ThingIFAPIBuilder(context, app, owner);
+        return new ThingIFAPIBuilder<>(context, app, owner);
     }
 
     /**
@@ -80,7 +80,7 @@ public class ThingIFAPIBuilder {
      * @return ThingIFAPIBuilder instance for method chaining.
      */
     @NonNull
-    public ThingIFAPIBuilder addSchema(
+    public ThingIFAPIBuilder<T> addSchema(
             @NonNull Schema schema) {
         if (schema == null) {
             throw new IllegalArgumentException("schema is null");
@@ -95,7 +95,7 @@ public class ThingIFAPIBuilder {
      * @param target target of {@link ThingIFAPI} instance.
      * @return builder instance for chaining call.
      */
-    public ThingIFAPIBuilder setTarget(Target target) {
+    public ThingIFAPIBuilder<T> setTarget(Target target) {
         this.target = target;
         return this;
     }
@@ -114,7 +114,7 @@ public class ThingIFAPIBuilder {
      * @return builder instance for chaining call.
      */
     @NonNull
-    public ThingIFAPIBuilder setTag(@Nullable String tag) {
+    public ThingIFAPIBuilder<T> setTag(@Nullable String tag) {
         this.tag = tag;
         return this;
     }
@@ -124,7 +124,7 @@ public class ThingIFAPIBuilder {
      * @param installationID installation id
      * @return builder instance for chaining call.
      */
-    public ThingIFAPIBuilder setInstallationID(String installationID) {
+    public ThingIFAPIBuilder<T> setInstallationID(String installationID) {
         this.installationID = installationID;
         return this;
     }
@@ -134,12 +134,12 @@ public class ThingIFAPIBuilder {
      * @throws IllegalStateException when schema is not present.
      */
     @NonNull
-    public ThingIFAPI build() {
+    public ThingIFAPI<T> build() {
         if (this.schemas.size() == 0) {
             throw new IllegalStateException("Builder has no schemas");
         }
         _Log.d(TAG, MessageFormat.format("Initialize ThingIFAPI AppID={0}, AppKey={1}, BaseUrl={2}", app.getAppID(), app.getAppKey(), app.getBaseUrl()));
-        return new ThingIFAPI(this.context, this.tag, app, this.owner, this.target, this.schemas, this.installationID);
+        return new ThingIFAPI<>(this.context, this.tag, app, this.owner, this.target, this.schemas, this.installationID);
     }
 
 }

--- a/thingif/src/main/java/com/kii/thingif/trigger/Trigger.java
+++ b/thingif/src/main/java/com/kii/thingif/trigger/Trigger.java
@@ -5,6 +5,7 @@ import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
+import com.kii.thingif.Alias;
 import com.kii.thingif.TypedID;
 import com.kii.thingif.command.Command;
 


### PR DESCRIPTION
The snippet to using generic for ThingIFAPI is like this:

```java

// TraitAlais API
        ThingIFAPI<TraitAlias> api = ThingIFAPIBuilder
                .<TraitAlias>newBuilder(
                        getApplicationContext(),
                        app,
                        owner
                .build();

        List<Action> actions = new ArrayList<>();
        TurnPower turnPower = new TurnPower(true);
        actions.add(turnPower);

        //Trait formatted command
        TraitAlias airConditionerAlias = new TraitAlias("AirConditionerAlias");
        List<Pair<TraitAlias, List<Action>>> traitActions = new ArrayList<>();
        traitActions.add(new Pair<>(airConditionerAlias, actions));
        CommandForm<TraitAlias> form = new CommandForm<>(traitActions);

        try {
            api.postNewCommand(form);
        }catch(Exception ex){
            //handle Exception
        }

// NonTraitAlias API
        ThingIFAPI<NonTraitAlias> api1 = ThingIFAPIBuilder
                .<NonTraitAlias>newBuilder(
                        getApplicationContext(),
                        app,
                        owner
                        )
                .build();

        //Non trait formatted command
        NonTraitAlias nonTraitAlias = new NonTraitAlias();
        List<Pair<NonTraitAlias, List<Action>>> nonTraitActions = new ArrayList<>();
        nonTraitActions.add(new Pair<>(nonTraitAlias, actions));
        CommandForm<NonTraitAlias> form1 = new CommandForm<>(nonTraitActions);

        try {
            api1.postNewCommand(form1);
        }catch(Exception ex){
            //handle Exception
        }
```