### PR TITLE
register action with action name string

### DIFF
--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -74,9 +74,9 @@ public class ThingIFAPI implements Parcelable {
     private final IoTRestClient restClient;
     private String installationID;
 
-    private final Map<String, List<Class<? extends Action>>> actionTypes;
-    private final Map<String, List<Class<? extends ActionResult>>> actionResultTypes;
-    private final Map<String, Class<? extends TargetState>> stateTypes;
+    private final Map<String, Map<String,List<Class<? extends Action>>>> actionTypes;
+    private final Map<String, Map<String,List<Class<? extends ActionResult>>>> actionResultTypes;
+    private final Map<String, Map<String,Class<? extends TargetState>>> stateTypes;
 
     /**
      * Try to load the instance of ThingIFAPI using stored serialized instance.
@@ -212,9 +212,9 @@ public class ThingIFAPI implements Parcelable {
             @Nullable Target target,
             @NonNull List<Schema> schemas,
             @Nullable String installationID,
-            @NonNull Map<String, List<Class<? extends Action>>> actionTypes,
-            @NonNull Map<String, List<Class<? extends ActionResult>>> actionResultTypes,
-            @NonNull Map<String, Class<? extends TargetState>> stateTypes
+            @NonNull Map<String, Map<String,List<Class<? extends Action>>>> actionTypes,
+            @NonNull Map<String, Map<String,List<Class<? extends ActionResult>>>> actionResultTypes,
+            @NonNull Map<String, Map<String,Class<? extends TargetState>>> stateTypes
             ) {
         // Parameters are checked by ThingIFAPIBuilder
         if (context != null) {

--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -74,8 +74,8 @@ public class ThingIFAPI implements Parcelable {
     private final IoTRestClient restClient;
     private String installationID;
 
-    private final Map<String, Map<String,List<Class<? extends Action>>>> actionTypes;
-    private final Map<String, Map<String,List<Class<? extends ActionResult>>>> actionResultTypes;
+    private final Map<String, Map<String,Class<? extends Action>>> actionTypes;
+    private final Map<String, Map<String,Class<? extends ActionResult>>> actionResultTypes;
     private final Map<String, Class<? extends TargetState>> stateTypes;
 
     /**
@@ -212,8 +212,8 @@ public class ThingIFAPI implements Parcelable {
             @Nullable Target target,
             @NonNull List<Schema> schemas,
             @Nullable String installationID,
-            @NonNull Map<String, Map<String,List<Class<? extends Action>>>> actionTypes,
-            @NonNull Map<String, Map<String,List<Class<? extends ActionResult>>>> actionResultTypes,
+            @NonNull Map<String, Map<String,Class<? extends Action>>> actionTypes,
+            @NonNull Map<String, Map<String,Class<? extends ActionResult>>> actionResultTypes,
             @NonNull Map<String, Class<? extends TargetState>> stateTypes
             ) {
         // Parameters are checked by ThingIFAPIBuilder

--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -76,7 +76,7 @@ public class ThingIFAPI implements Parcelable {
 
     private final Map<String, Map<String,List<Class<? extends Action>>>> actionTypes;
     private final Map<String, Map<String,List<Class<? extends ActionResult>>>> actionResultTypes;
-    private final Map<String, Map<String,Class<? extends TargetState>>> stateTypes;
+    private final Map<String, Class<? extends TargetState>> stateTypes;
 
     /**
      * Try to load the instance of ThingIFAPI using stored serialized instance.
@@ -214,7 +214,7 @@ public class ThingIFAPI implements Parcelable {
             @Nullable String installationID,
             @NonNull Map<String, Map<String,List<Class<? extends Action>>>> actionTypes,
             @NonNull Map<String, Map<String,List<Class<? extends ActionResult>>>> actionResultTypes,
-            @NonNull Map<String, Map<String,Class<? extends TargetState>>> stateTypes
+            @NonNull Map<String, Class<? extends TargetState>> stateTypes
             ) {
         // Parameters are checked by ThingIFAPIBuilder
         if (context != null) {

--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPIBuilder.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPIBuilder.java
@@ -28,7 +28,7 @@ public class ThingIFAPIBuilder {
 
     private final @NonNull Map<String, Map<String, List<Class<? extends Action>>>> actionTypes;
     private final @NonNull Map<String, Map<String,List<Class<? extends ActionResult>>>> actionResultTypes;
-    private final @NonNull Map<String, Map<String,Class<? extends TargetState>>> stateTypes;
+    private final @NonNull Map<String, Class<? extends TargetState>> stateTypes;
 
     private ThingIFAPIBuilder(
             @Nullable Context context,
@@ -36,7 +36,7 @@ public class ThingIFAPIBuilder {
             @NonNull Owner owner,
             @NonNull Map<String, Map<String,List<Class<? extends Action>>>> actionTypes,
             @NonNull Map<String, Map<String,List<Class<? extends ActionResult>>>> actionResultTypes,
-            @NonNull Map<String, Map<String,Class<? extends TargetState>>> stateTypes
+            @NonNull Map<String, Class<? extends TargetState>> stateTypes
             ) {
         this.context = context;
         this.app = app;
@@ -59,7 +59,7 @@ public class ThingIFAPIBuilder {
             @NonNull Owner owner,
             @NonNull Map<String, Map<String,List<Class<? extends Action>>>> actionTypes,
             @NonNull Map<String, Map<String,List<Class<? extends ActionResult>>>> actionResultTypes,
-            @NonNull Map<String, Map<String,Class<? extends TargetState>>> stateTypes) {
+            @NonNull Map<String, Class<? extends TargetState>> stateTypes) {
         if (context == null) {
             throw new IllegalArgumentException("context is null");
         }
@@ -86,7 +86,7 @@ public class ThingIFAPIBuilder {
             @NonNull Owner owner,
             @NonNull Map<String, Map<String,List<Class<? extends Action>>>> actionTypes,
             @NonNull Map<String, Map<String,List<Class<? extends ActionResult>>>> actionResultTypes,
-            @NonNull Map<String, Map<String,Class<? extends TargetState>>> stateTypes) {
+            @NonNull Map<String, Class<? extends TargetState>> stateTypes) {
         if (app == null) {
             throw new IllegalArgumentException("app is null");
         }
@@ -206,7 +206,7 @@ public class ThingIFAPIBuilder {
     @NonNull
     public ThingIFAPIBuilder registerTargetState(
             @NonNull String alias,
-            @NonNull Map<String,Class<? extends TargetState>> stateClass) {
+            @NonNull Class<? extends TargetState> stateClass) {
         this.stateTypes.put(alias, stateClass);
         return this;
     }

--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPIBuilder.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPIBuilder.java
@@ -26,16 +26,16 @@ public class ThingIFAPIBuilder {
     private @Nullable String tag;
     private final @NonNull List<Schema> schemas = new ArrayList<Schema>();
 
-    private final @NonNull Map<String, Map<String, List<Class<? extends Action>>>> actionTypes;
-    private final @NonNull Map<String, Map<String,List<Class<? extends ActionResult>>>> actionResultTypes;
+    private final @NonNull Map<String, Map<String, Class<? extends Action>>> actionTypes;
+    private final @NonNull Map<String, Map<String, Class<? extends ActionResult>>> actionResultTypes;
     private final @NonNull Map<String, Class<? extends TargetState>> stateTypes;
 
     private ThingIFAPIBuilder(
             @Nullable Context context,
             @NonNull KiiApp app,
             @NonNull Owner owner,
-            @NonNull Map<String, Map<String,List<Class<? extends Action>>>> actionTypes,
-            @NonNull Map<String, Map<String,List<Class<? extends ActionResult>>>> actionResultTypes,
+            @NonNull Map<String, Map<String,Class<? extends Action>>> actionTypes,
+            @NonNull Map<String, Map<String,Class<? extends ActionResult>>> actionResultTypes,
             @NonNull Map<String, Class<? extends TargetState>> stateTypes
             ) {
         this.context = context;
@@ -57,8 +57,8 @@ public class ThingIFAPIBuilder {
             @NonNull Context context,
             @NonNull KiiApp app,
             @NonNull Owner owner,
-            @NonNull Map<String, Map<String,List<Class<? extends Action>>>> actionTypes,
-            @NonNull Map<String, Map<String,List<Class<? extends ActionResult>>>> actionResultTypes,
+            @NonNull Map<String, Map<String,Class<? extends Action>>> actionTypes,
+            @NonNull Map<String, Map<String,Class<? extends ActionResult>>> actionResultTypes,
             @NonNull Map<String, Class<? extends TargetState>> stateTypes) {
         if (context == null) {
             throw new IllegalArgumentException("context is null");
@@ -84,8 +84,8 @@ public class ThingIFAPIBuilder {
     public static ThingIFAPIBuilder _newBuilder(
             @NonNull KiiApp app,
             @NonNull Owner owner,
-            @NonNull Map<String, Map<String,List<Class<? extends Action>>>> actionTypes,
-            @NonNull Map<String, Map<String,List<Class<? extends ActionResult>>>> actionResultTypes,
+            @NonNull Map<String, Map<String,Class<? extends Action>>> actionTypes,
+            @NonNull Map<String, Map<String,Class<? extends ActionResult>>> actionResultTypes,
             @NonNull Map<String, Class<? extends TargetState>> stateTypes) {
         if (app == null) {
             throw new IllegalArgumentException("app is null");
@@ -174,7 +174,7 @@ public class ThingIFAPIBuilder {
     @NonNull
     public ThingIFAPIBuilder registerActions(
             @NonNull String alias,
-            @NonNull Map<String,List<Class<? extends Action>>> actionClasses){
+            @NonNull Map<String,Class<? extends Action>> actionClasses){
         this.actionTypes.put(alias, actionClasses);
         return this;
     }
@@ -190,7 +190,7 @@ public class ThingIFAPIBuilder {
     @NonNull
     public ThingIFAPIBuilder registerActionResults(
             @NonNull String alias,
-            @NonNull Map<String,List<Class<? extends ActionResult>>> actionResultClasses) {
+            @NonNull Map<String,Class<? extends ActionResult>> actionResultClasses) {
         this.actionResultTypes.put(alias, actionResultClasses);
         return this;
     }

--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPIBuilder.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPIBuilder.java
@@ -26,17 +26,17 @@ public class ThingIFAPIBuilder {
     private @Nullable String tag;
     private final @NonNull List<Schema> schemas = new ArrayList<Schema>();
 
-    private final @NonNull Map<String, List<Class<? extends Action>>> actionTypes;
-    private final @NonNull Map<String, List<Class<? extends ActionResult>>> actionResultTypes;
-    private final @NonNull Map<String, Class<? extends TargetState>> stateTypes;
+    private final @NonNull Map<String, Map<String, List<Class<? extends Action>>>> actionTypes;
+    private final @NonNull Map<String, Map<String,List<Class<? extends ActionResult>>>> actionResultTypes;
+    private final @NonNull Map<String, Map<String,Class<? extends TargetState>>> stateTypes;
 
     private ThingIFAPIBuilder(
             @Nullable Context context,
             @NonNull KiiApp app,
             @NonNull Owner owner,
-            @NonNull Map<String, List<Class<? extends Action>>> actionTypes,
-            @NonNull Map<String, List<Class<? extends ActionResult>>> actionResultTypes,
-            @NonNull Map<String, Class<? extends TargetState>> stateTypes
+            @NonNull Map<String, Map<String,List<Class<? extends Action>>>> actionTypes,
+            @NonNull Map<String, Map<String,List<Class<? extends ActionResult>>>> actionResultTypes,
+            @NonNull Map<String, Map<String,Class<? extends TargetState>>> stateTypes
             ) {
         this.context = context;
         this.app = app;
@@ -57,9 +57,9 @@ public class ThingIFAPIBuilder {
             @NonNull Context context,
             @NonNull KiiApp app,
             @NonNull Owner owner,
-            @NonNull Map<String, List<Class<? extends Action>>> actionTypes,
-            @NonNull Map<String, List<Class<? extends ActionResult>>> actionResultTypes,
-            @NonNull Map<String, Class<? extends TargetState>> stateTypes) {
+            @NonNull Map<String, Map<String,List<Class<? extends Action>>>> actionTypes,
+            @NonNull Map<String, Map<String,List<Class<? extends ActionResult>>>> actionResultTypes,
+            @NonNull Map<String, Map<String,Class<? extends TargetState>>> stateTypes) {
         if (context == null) {
             throw new IllegalArgumentException("context is null");
         }
@@ -84,9 +84,9 @@ public class ThingIFAPIBuilder {
     public static ThingIFAPIBuilder _newBuilder(
             @NonNull KiiApp app,
             @NonNull Owner owner,
-            @NonNull Map<String, List<Class<? extends Action>>> actionTypes,
-            @NonNull Map<String, List<Class<? extends ActionResult>>> actionResultTypes,
-            @NonNull Map<String, Class<? extends TargetState>> stateTypes) {
+            @NonNull Map<String, Map<String,List<Class<? extends Action>>>> actionTypes,
+            @NonNull Map<String, Map<String,List<Class<? extends ActionResult>>>> actionResultTypes,
+            @NonNull Map<String, Map<String,Class<? extends TargetState>>> stateTypes) {
         if (app == null) {
             throw new IllegalArgumentException("app is null");
         }
@@ -174,7 +174,7 @@ public class ThingIFAPIBuilder {
     @NonNull
     public ThingIFAPIBuilder registerActions(
             @NonNull String alias,
-            @NonNull List<Class<? extends Action>> actionClasses){
+            @NonNull Map<String,List<Class<? extends Action>>> actionClasses){
         this.actionTypes.put(alias, actionClasses);
         return this;
     }
@@ -190,7 +190,7 @@ public class ThingIFAPIBuilder {
     @NonNull
     public ThingIFAPIBuilder registerActionResults(
             @NonNull String alias,
-            @NonNull List<Class<? extends ActionResult>> actionResultClasses) {
+            @NonNull Map<String,List<Class<? extends ActionResult>>> actionResultClasses) {
         this.actionResultTypes.put(alias, actionResultClasses);
         return this;
     }
@@ -206,7 +206,7 @@ public class ThingIFAPIBuilder {
     @NonNull
     public ThingIFAPIBuilder registerTargetState(
             @NonNull String alias,
-            @NonNull Class<TargetState> stateClass) {
+            @NonNull Map<String,Class<? extends TargetState>> stateClass) {
         this.stateTypes.put(alias, stateClass);
         return this;
     }


### PR DESCRIPTION
Deserializing action needs name of action, so the action name should in the map object.  The PR improves the registration of Actions of ActionResults