### PR TITLE
Fix build error

### DIFF
--- a/thingif/src/main/java/com/kii/thingif/clause/trigger/AndClauseInTrigger.java
+++ b/thingif/src/main/java/com/kii/thingif/clause/trigger/AndClauseInTrigger.java
@@ -1,5 +1,6 @@
 package com.kii.thingif.clause.trigger;
 
+import android.os.Parcel;
 import android.support.annotation.NonNull;
 
 import com.kii.thingif.clause.base.BaseAnd;
@@ -35,4 +36,38 @@ public class AndClauseInTrigger implements BaseAnd<TriggerClause>, TriggerClause
         // TODO: implement me
         return null;
     }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeInt(this.clauses.size());
+        for (TriggerClause clause: this.clauses){
+            dest.writeParcelable(clause, flags);
+        }
+    }
+
+    private AndClauseInTrigger(Parcel in) {
+        this.clauses = new ArrayList<>();
+        int size = in.readInt();
+        for (int i= 0; i<size; i++) {
+            TriggerClause clause = in.readParcelable(TriggerClause.class.getClassLoader());
+            this.clauses.add(clause);
+        }
+    }
+
+    public static final Creator<AndClauseInTrigger> CREATOR = new Creator<AndClauseInTrigger>() {
+        @Override
+        public AndClauseInTrigger createFromParcel(Parcel source) {
+            return new AndClauseInTrigger(source);
+        }
+
+        @Override
+        public AndClauseInTrigger[] newArray(int size) {
+            return new AndClauseInTrigger[size];
+        }
+    };
 }

--- a/thingif/src/main/java/com/kii/thingif/clause/trigger/EqualsClauseInTrigger.java
+++ b/thingif/src/main/java/com/kii/thingif/clause/trigger/EqualsClauseInTrigger.java
@@ -1,5 +1,6 @@
 package com.kii.thingif.clause.trigger;
 
+import android.os.Parcel;
 import android.support.annotation.NonNull;
 
 import com.kii.thingif.clause.base.BaseEquals;
@@ -53,4 +54,34 @@ public class EqualsClauseInTrigger implements BaseEquals, TriggerClause{
         //TODO: implement me
         return null;
     }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(this.alias);
+        dest.writeString(this.field);
+        dest.writeValue(this.value);
+    }
+
+    private EqualsClauseInTrigger(Parcel in) {
+        this.alias = in.readString();
+        this.field = in.readString();
+        this.value = in.readValue(null);
+    }
+
+    public static final Creator<EqualsClauseInTrigger> CREATOR = new Creator<EqualsClauseInTrigger>() {
+        @Override
+        public EqualsClauseInTrigger createFromParcel(Parcel source) {
+            return new EqualsClauseInTrigger(source);
+        }
+
+        @Override
+        public EqualsClauseInTrigger[] newArray(int size) {
+            return new EqualsClauseInTrigger[size];
+        }
+    };
 }

--- a/thingif/src/main/java/com/kii/thingif/clause/trigger/NotEqualsClauseInTrigger.java
+++ b/thingif/src/main/java/com/kii/thingif/clause/trigger/NotEqualsClauseInTrigger.java
@@ -1,5 +1,7 @@
 package com.kii.thingif.clause.trigger;
 
+import android.os.Parcel;
+
 import com.kii.thingif.clause.base.BaseNotEquals;
 
 import org.json.JSONObject;
@@ -21,4 +23,30 @@ public class NotEqualsClauseInTrigger implements BaseNotEquals, TriggerClause {
         //TODO: implement me
         return null;
     }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeParcelable(this.equals, flags);
+    }
+
+    private NotEqualsClauseInTrigger(Parcel in) {
+        this.equals = in.readParcelable(EqualsClauseInTrigger.class.getClassLoader());
+    }
+
+    public static final Creator<NotEqualsClauseInTrigger> CREATOR = new Creator<NotEqualsClauseInTrigger>() {
+        @Override
+        public NotEqualsClauseInTrigger createFromParcel(Parcel source) {
+            return new NotEqualsClauseInTrigger(source);
+        }
+
+        @Override
+        public NotEqualsClauseInTrigger[] newArray(int size) {
+            return new NotEqualsClauseInTrigger[size];
+        }
+    };
 }

--- a/thingif/src/main/java/com/kii/thingif/clause/trigger/OrClauseInTrigger.java
+++ b/thingif/src/main/java/com/kii/thingif/clause/trigger/OrClauseInTrigger.java
@@ -1,5 +1,7 @@
 package com.kii.thingif.clause.trigger;
 
+import android.os.Parcel;
+
 import com.kii.thingif.clause.base.BaseOr;
 
 import org.json.JSONObject;
@@ -33,4 +35,38 @@ public class OrClauseInTrigger implements BaseOr<TriggerClause>, TriggerClause {
         // TODO: implement me
         return null;
     }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeInt(this.clauses.size());
+        for (TriggerClause clause: this.clauses){
+            dest.writeParcelable(clause, flags);
+        }
+    }
+
+    private OrClauseInTrigger(Parcel in) {
+        this.clauses = new ArrayList<>();
+        int size = in.readInt();
+        for (int i= 0; i<size; i++) {
+            TriggerClause clause = in.readParcelable(TriggerClause.class.getClassLoader());
+            this.clauses.add(clause);
+        }
+    }
+
+    public static final Creator<OrClauseInTrigger> CREATOR = new Creator<OrClauseInTrigger>() {
+        @Override
+        public OrClauseInTrigger createFromParcel(Parcel source) {
+            return new OrClauseInTrigger(source);
+        }
+
+        @Override
+        public OrClauseInTrigger[] newArray(int size) {
+            return new OrClauseInTrigger[size];
+        }
+    };
 }

--- a/thingif/src/main/java/com/kii/thingif/clause/trigger/RangeClauseInTrigger.java
+++ b/thingif/src/main/java/com/kii/thingif/clause/trigger/RangeClauseInTrigger.java
@@ -1,5 +1,6 @@
 package com.kii.thingif.clause.trigger;
 
+import android.os.Parcel;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
@@ -134,4 +135,40 @@ public class RangeClauseInTrigger implements BaseRange, TriggerClause {
         //TODO: implement me
         return null;
     }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(this.alias);
+        dest.writeString(this.field);
+        dest.writeValue(this.lowerLimit);
+        dest.writeValue(this.upperLimit);
+        dest.writeValue(this.lowerIncluded);
+        dest.writeValue(this.upperIncluded);
+    }
+
+    private RangeClauseInTrigger(Parcel in) {
+        this.alias = in.readString();
+        this.field = in.readString();
+        this.lowerLimit = (Number) in.readValue(Number.class.getClassLoader());
+        this.upperLimit = (Number) in.readValue(Number.class.getClassLoader());
+        this.lowerIncluded = (Boolean) in.readValue(Boolean.class.getClassLoader());
+        this.upperIncluded = (Boolean) in.readValue(Boolean.class.getClassLoader());
+    }
+
+    public static final Creator<RangeClauseInTrigger> CREATOR = new Creator<RangeClauseInTrigger>() {
+        @Override
+        public RangeClauseInTrigger createFromParcel(Parcel source) {
+            return new RangeClauseInTrigger(source);
+        }
+
+        @Override
+        public RangeClauseInTrigger[] newArray(int size) {
+            return new RangeClauseInTrigger[size];
+        }
+    };
 }

--- a/thingif/src/main/java/com/kii/thingif/clause/trigger/TriggerClause.java
+++ b/thingif/src/main/java/com/kii/thingif/clause/trigger/TriggerClause.java
@@ -1,6 +1,8 @@
 package com.kii.thingif.clause.trigger;
 
+import android.os.Parcelable;
+
 import com.kii.thingif.clause.base.BaseClause;
 
-public interface TriggerClause extends BaseClause {
+public interface TriggerClause extends BaseClause, Parcelable {
 }


### PR DESCRIPTION
Build failure cause by the reason:
`com.kii.thingif.trigger.Condition`  class requires `Parcelable`, `QueryClause` as attribute of this class also need to implement `Parcelable`. 

Fixed in the PR
- extend `Parcelable` for `QueryClause` interface.
- Implement parcelable for AndClauseInTrigger
- Implement parcelable for EqualsClauseInTrigger
- Implement Parcelable for NotEqualsClauseInTrigger
- Implement Parcelable for OrClauseInTrigger
- Implement parcelable for RangeClauseInTrigger