### PR TITLE
Impl equals in trigger

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/circle.yml
+++ b/circle.yml
@@ -2,12 +2,6 @@ machine:
   environment:
     QEMU_AUDIO_DRV: none
 
-dependencies:
-  pre:
-    - echo y | android update sdk --no-ui --filter platform
-    - echo y | android update sdk --no-ui --all --filter android-24
-    - echo y | android update sdk --no-ui --all --filter build-tools-24.0.3
-
 test:
   pre:
     # build sdk

--- a/circle.yml
+++ b/circle.yml
@@ -1,21 +1,12 @@
 machine:
   environment:
-    ADB_INSTALL_TIMEOUT: 5
-  java:
-    version: oraclejdk8
+    QEMU_AUDIO_DRV: none
 
 dependencies:
   pre:
     - echo y | android update sdk --no-ui --filter platform
     - echo y | android update sdk --no-ui --all --filter android-24
-    - echo y | android update sdk --no-ui --all --filter build-tools-24.0.0
-    - echo no | android create avd --force --name my-android-17 --target android-17 --sdcard 128M
-    - >
-      cat ~/.android/avd/my-android-17.avd/config.ini |
-      sed -e 's/^\(vm\.heapSize=\)[0-9]*$/\1128/' |
-      sed -e 's/^\(hw\.ramSize=\)[0-9]*$/\1512/' >
-      ~/.android/avd/my-android-17.avd/config2.ini
-    - mv ~/.android/avd/my-android-17.avd/config2.ini ~/.android/avd/my-android-17.avd/config.ini
+    - echo y | android update sdk --no-ui --all --filter build-tools-24.0.3
 
 test:
   pre:
@@ -33,13 +24,13 @@ test:
     - ./gradlew :thingif:javadocArchive
     - cp thingif/build/outputs/archive/apidoc*.zip $CIRCLE_ARTIFACTS
 
-  override:
-    # start the emulator
-    - emulator -memory 512 -avd my-android-17 -no-audio -no-window:
+    # start emulator
+    - emulator -avd circleci-android24 -no-window:
         background: true
         parallel: true
-    # wait for it to have booted
     - circle-android wait-for-boot
+
+  override:
     # run small tests  against the emulator.
     - ./gradlew :thingif:connectedAndroidTest
     # copy the test results to the test results directory.

--- a/circle.yml
+++ b/circle.yml
@@ -1,16 +1,7 @@
 machine:
   environment:
-    ADB_INSTALL_TIMEOUT: 5
+    QEMU_AUDIO_DRV: none
 
-dependencies:
-  pre:
-    - echo no | android create avd --force --name my-android-17 --target android-17 --sdcard 128M
-    - >
-      cat ~/.android/avd/my-android-17.avd/config.ini |
-      sed -e 's/^\(vm\.heapSize=\)[0-9]*$/\1128/' |
-      sed -e 's/^\(hw\.ramSize=\)[0-9]*$/\1512/' >
-      ~/.android/avd/my-android-17.avd/config2.ini
-    - mv ~/.android/avd/my-android-17.avd/config2.ini ~/.android/avd/my-android-17.avd/config.ini
 test:
   pre:
     # build sdk
@@ -27,14 +18,13 @@ test:
     - ./gradlew :thingif:javadocArchive
     - cp thingif/build/outputs/archive/apidoc*.zip $CIRCLE_ARTIFACTS
 
-  override:
-    # start the emulator
-    - emulator -memory 512 -avd my-android-17 -no-audio -no-window:
+    # start emulator
+    - emulator -avd circleci-android24 -no-window:
         background: true
         parallel: true
-    # wait for it to have booted
     - circle-android wait-for-boot
 
+  override:
     # run local unit tests
     - ./gradlew :thingif:test
     - mkdir $CIRCLE_TEST_REPORTS/local_ut_reports; cp -r thingif/build/test-results/debug/* $CIRCLE_TEST_REPORTS/local_ut_reports/

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,16 @@
 machine:
   environment:
-    QEMU_AUDIO_DRV: none
+    ADB_INSTALL_TIMEOUT: 5
 
+dependencies:
+  pre:
+    - echo no | android create avd --force --name my-android-17 --target android-17 --sdcard 128M
+    - >
+      cat ~/.android/avd/my-android-17.avd/config.ini |
+      sed -e 's/^\(vm\.heapSize=\)[0-9]*$/\1128/' |
+      sed -e 's/^\(hw\.ramSize=\)[0-9]*$/\1512/' >
+      ~/.android/avd/my-android-17.avd/config2.ini
+    - mv ~/.android/avd/my-android-17.avd/config2.ini ~/.android/avd/my-android-17.avd/config.ini
 test:
   pre:
     # build sdk
@@ -18,13 +27,14 @@ test:
     - ./gradlew :thingif:javadocArchive
     - cp thingif/build/outputs/archive/apidoc*.zip $CIRCLE_ARTIFACTS
 
-    # start emulator
-    - emulator -avd circleci-android24 -no-window:
+  override:
+    # start the emulator
+    - emulator -memory 512 -avd my-android-17 -no-audio -no-window:
         background: true
         parallel: true
+    # wait for it to have booted
     - circle-android wait-for-boot
 
-  override:
     # run local unit tests
     - ./gradlew :thingif:test
     - mkdir $CIRCLE_TEST_REPORTS/local_ut_reports; cp -r thingif/build/test-results/debug/* $CIRCLE_TEST_REPORTS/local_ut_reports/

--- a/circle.yml
+++ b/circle.yml
@@ -25,10 +25,15 @@ test:
     - circle-android wait-for-boot
 
   override:
-    # run small tests  against the emulator.
+    # run local unit tests
+    - ./gradlew :thingif:test
+    - mkdir $CIRCLE_TEST_REPORTS/local_ut_reports; cp -r thingif/build/test-results/debug/* $CIRCLE_TEST_REPORTS/local_ut_reports/
+
+    # run instrumented small tests  against the emulator.
     - ./gradlew :thingif:connectedAndroidTest
     # copy the test results to the test results directory.
-    - cp -r thingif/build/outputs/androidTest-results/connected/*.xml $CIRCLE_TEST_REPORTS/small_tests.xml
+    - cp -r thingif/build/outputs/androidTest-results/connected/*.xml $CIRCLE_TEST_REPORTS/instrumented_small_tests.xml
+
     # copy the logcat file to test results directory.
     - adb logcat -d > logcat.txt
     - mv logcat.txt $CIRCLE_ARTIFACTS/logcat_small_test.txt

--- a/thingif/build.gradle
+++ b/thingif/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion '24'
+    buildToolsVersion '24.0.3'
     publishNonDefault true
 
     defaultConfig {
         minSdkVersion 10
-        targetSdkVersion 23
+        targetSdkVersion 24
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -22,6 +22,16 @@ android {
     packagingOptions {
         exclude 'LICENSE.txt'
         exclude 'META-INF/LICENSE.txt'
+    }
+
+    sourceSets {
+        String sharedTestDir = 'src/testLib/java'
+        test {
+            java.srcDir sharedTestDir
+        }
+        androidTest {
+            java.srcDir sharedTestDir
+        }
     }
 }
 
@@ -78,21 +88,25 @@ android.libraryVariants.all { variant ->
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:support-annotations:23.1.0'
+    compile 'com.android.support:support-annotations:25.1.0'
 
-    compile 'com.google.code.gson:gson:2.3.1'
+    compile 'com.google.code.gson:gson:2.4'
     compile 'com.squareup.okhttp:okhttp:2.3.0'
+
+    // dependencies for unit tests
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.json:json:20160810'
+
     androidTestCompile 'com.crittercism.dexmaker:dexmaker:1.4'
     androidTestCompile 'com.crittercism.dexmaker:dexmaker-mockito:1.4'
     androidTestCompile 'com.crittercism.dexmaker:dexmaker-dx:1.4'
     androidTestCompile 'org.mockito:mockito-core:1.10.19'
     androidTestCompile 'com.squareup.okhttp:mockwebserver:2.3.0'
-    androidTestCompile 'com.android.support.test:runner:0.3'
-    androidTestCompile 'com.android.support.test:rules:0.3'
-    androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2'
-    androidTestCompile 'com.android.support.test.uiautomator:uiautomator-v18:2.1.1'
+    androidTestCompile 'com.android.support.test:runner:0.5'
+    androidTestCompile 'com.android.support.test:rules:0.5'
+    androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
+    androidTestCompile 'com.android.support.test.uiautomator:uiautomator-v18:2.1.2'
     androidTestCompile 'commons-lang:commons-lang:2.6'
-    androidTestCompile 'org.mockito:mockito-core:1.10.19'
 }
 
 task setBranch << {

--- a/thingif/src/androidTest/java/com/kii/thingif/clause/trigger/ClauseParcelableTest.java
+++ b/thingif/src/androidTest/java/com/kii/thingif/clause/trigger/ClauseParcelableTest.java
@@ -1,0 +1,44 @@
+package com.kii.thingif.clause.trigger;
+
+import android.os.Parcel;
+import android.support.test.runner.AndroidJUnit4;
+
+import com.kii.thingif.SmallTestBase;
+
+import junit.framework.Assert;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(AndroidJUnit4.class)
+public class ClauseParcelableTest extends SmallTestBase{
+    @Test
+    public void stringEqualsTest() throws Exception {
+        EqualsClauseInTrigger clause = new EqualsClauseInTrigger("alias", "f", "value");
+        Parcel parcel = Parcel.obtain();
+        clause.writeToParcel(parcel, clause.describeContents());
+        parcel.setDataPosition(0);
+        EqualsClauseInTrigger deserializedClause = EqualsClauseInTrigger.CREATOR.createFromParcel(parcel);
+        Assert.assertEquals(clause, deserializedClause);
+    }
+
+    @Test
+    public void numberEqualsTest() throws Exception {
+        EqualsClauseInTrigger clause = new EqualsClauseInTrigger("alias", "f", 1);
+        Parcel parcel = Parcel.obtain();
+        clause.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+        EqualsClauseInTrigger deserializedClause = EqualsClauseInTrigger.CREATOR.createFromParcel(parcel);
+        Assert.assertEquals(clause, deserializedClause);
+    }
+
+    @Test
+    public void booleanEqualsTest() throws Exception {
+        EqualsClauseInTrigger clause = new EqualsClauseInTrigger("alias", "f", true);
+        Parcel parcel = Parcel.obtain();
+        clause.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+        EqualsClauseInTrigger deserializedClause = EqualsClauseInTrigger.CREATOR.createFromParcel(parcel);
+        Assert.assertEquals(clause, deserializedClause);
+    }
+}

--- a/thingif/src/androidTest_old/java/com/kii/thingif/trigger/clause/ClauseParcelableTest.java
+++ b/thingif/src/androidTest_old/java/com/kii/thingif/trigger/clause/ClauseParcelableTest.java
@@ -12,33 +12,6 @@ import org.junit.runner.RunWith;
 @RunWith(AndroidJUnit4.class)
 public class ClauseParcelableTest extends SmallTestBase {
     @Test
-    public void stringEqualsTest() throws Exception {
-        Equals clause = new Equals("f", "value");
-        Parcel parcel = Parcel.obtain();
-        clause.writeToParcel(parcel, 0);
-        parcel.setDataPosition(0);
-        Equals deserializedClause = Equals.CREATOR.createFromParcel(parcel);
-        Assert.assertEquals(clause, deserializedClause);
-    }
-    @Test
-    public void numberEqualsTest() throws Exception {
-        Equals clause = new Equals("f", 1);
-        Parcel parcel = Parcel.obtain();
-        clause.writeToParcel(parcel, 0);
-        parcel.setDataPosition(0);
-        Equals deserializedClause = Equals.CREATOR.createFromParcel(parcel);
-        Assert.assertEquals(clause, deserializedClause);
-    }
-    @Test
-    public void booleanEqualsTest() throws Exception {
-        Equals clause = new Equals("f", true);
-        Parcel parcel = Parcel.obtain();
-        clause.writeToParcel(parcel, 0);
-        parcel.setDataPosition(0);
-        Equals deserializedClause = Equals.CREATOR.createFromParcel(parcel);
-        Assert.assertEquals(clause, deserializedClause);
-    }
-    @Test
     public void stringNotEqualsTest() throws Exception {
         NotEquals clause = new NotEquals(new Equals("f", "value"));
         Parcel parcel = Parcel.obtain();

--- a/thingif/src/main/java/com/kii/thingif/clause/trigger/EqualsClauseInTrigger.java
+++ b/thingif/src/main/java/com/kii/thingif/clause/trigger/EqualsClauseInTrigger.java
@@ -5,6 +5,7 @@ import android.support.annotation.NonNull;
 
 import com.kii.thingif.clause.base.BaseEquals;
 
+import org.json.JSONException;
 import org.json.JSONObject;
 
 public class EqualsClauseInTrigger implements BaseEquals, TriggerClause{
@@ -51,8 +52,16 @@ public class EqualsClauseInTrigger implements BaseEquals, TriggerClause{
 
     @Override
     public JSONObject toJSONObject() {
-        //TODO: implement me
-        return null;
+        JSONObject ret = new JSONObject();
+        try {
+            ret.put("type", "eq");
+            ret.put("alias", alias);
+            ret.put("field", field);
+            ret.put("value", value);
+        }catch (JSONException ex) {
+            throw new RuntimeException(ex);
+        }
+        return ret;
     }
 
     @Override
@@ -70,7 +79,7 @@ public class EqualsClauseInTrigger implements BaseEquals, TriggerClause{
     private EqualsClauseInTrigger(Parcel in) {
         this.alias = in.readString();
         this.field = in.readString();
-        this.value = in.readValue(null);
+        this.value = in.readValue(Object.class.getClassLoader());
     }
 
     public static final Creator<EqualsClauseInTrigger> CREATOR = new Creator<EqualsClauseInTrigger>() {
@@ -84,4 +93,14 @@ public class EqualsClauseInTrigger implements BaseEquals, TriggerClause{
             return new EqualsClauseInTrigger[size];
         }
     };
+
+    @Override
+    public boolean equals(Object o) {
+        if(this == o) return true;
+        if(o == null || getClass() != o.getClass()) return false;
+        EqualsClauseInTrigger equals = (EqualsClauseInTrigger) o;
+        if(!alias.equals(equals.alias)) return false;
+        if(!field.equals(equals.field)) return false;
+        return value.equals(equals.value);
+    }
 }

--- a/thingif/src/test/java/com/kii/thingif/clause/trigger/EqulasClauseTest.java
+++ b/thingif/src/test/java/com/kii/thingif/clause/trigger/EqulasClauseTest.java
@@ -1,0 +1,75 @@
+package com.kii.thingif.clause.trigger;
+
+import com.kii.thingif.SmallTestBase;
+import com.kii.thingif.clause.query.EqualsClauseInQuery;
+
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class EqulasClauseTest extends SmallTestBase{
+
+    @Test
+    public void testEquals() throws Exception {
+        EqualsClauseInTrigger clause = new EqualsClauseInTrigger("alias", "f", "v");
+
+        // objects should equals to
+        Object[] sameObjects = {
+                clause,
+                new EqualsClauseInTrigger("alias", "f", "v")
+        };
+        for (int i= 0; i < sameObjects.length; i++) {
+            Assert.assertTrue("failed on ["+i+"]", clause.equals(sameObjects[i]));
+        }
+
+        // objects should not equals to
+        Object[] diffObjects = {
+                null,
+                new EqualsClauseInTrigger("alias1", "f", "v"),
+                new EqualsClauseInTrigger("alias", "f1", "v"),
+                new EqualsClauseInTrigger("alias", "f", "v1"),
+                new EqualsClauseInTrigger("alias", "f", 1),
+                new EqualsClauseInQuery("f", "v")
+        };
+        for (int j=0; j < diffObjects.length; j++) {
+            Assert.assertFalse("failed on ["+j+"]", clause.equals(diffObjects[j]));
+        }
+    }
+
+    @Test
+    public void testToJSONObject() {
+        String alias = "alias";
+        String field = "f";
+        try {
+            JSONObject[] expectedJsons = {
+                    new JSONObject()
+                            .put("type", "eq")
+                            .put("alias", alias)
+                            .put("field", field)
+                            .put("value", "v"),
+                    new JSONObject()
+                            .put("type", "eq")
+                            .put("alias", alias)
+                            .put("field", field)
+                            .put("value", 1),
+                    new JSONObject()
+                            .put("type", "eq")
+                            .put("alias", alias)
+                            .put("field", field)
+                            .put("value", true)
+            };
+
+            EqualsClauseInTrigger[] clauses = {
+                    new EqualsClauseInTrigger(alias, field, "v"),
+                    new EqualsClauseInTrigger(alias, field, 1),
+                    new EqualsClauseInTrigger(alias, field, true)
+            };
+
+            for (int i=0; i < clauses.length; i++) {
+                assertJSONObject("failed on ["+i+"]", expectedJsons[i], clauses[i].toJSONObject());
+            }
+        }catch (Exception ex) {
+            Assert.fail("failed caused by exception:"+ex.toString());
+        }
+    }
+}

--- a/thingif/src/testLib/java/com/kii/thingif/SmallTestBase.java
+++ b/thingif/src/testLib/java/com/kii/thingif/SmallTestBase.java
@@ -1,25 +1,17 @@
 package com.kii.thingif;
 
-import android.test.AndroidTestCase;
 
-import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import com.kii.thingif.internal.InternalUtils;
 
 import junit.framework.Assert;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.junit.Before;
 
-public abstract class SmallTestBase extends AndroidTestCase {
-    @Before
-    public void before() throws Exception {
-        // GsonRepository will cache the schema to static field.
-        // So unit test must clear that cache in order to avoid the side effect.
-        InternalUtils.gsonRepositoryClearCache();
-    }
+public class SmallTestBase {
+
+
     protected void assertJSONObject(
             String errorMessage,
             JSONObject expected,
@@ -51,7 +43,7 @@ public abstract class SmallTestBase extends AndroidTestCase {
             } else if (a instanceof JSONArray) {
                 assertJSONArray((JSONArray)e, (JSONArray)a);
             } else {
-                assertEquals(e, a);
+                Assert.assertEquals(e, a);
             }
         }
     }


### PR DESCRIPTION
### Reorganize test file structor
divide small tests into 2 kinds of tests: local unit test and instrumented unit tests(reference for these 2 tests: https://developer.android.com/training/testing/start/index.html).
- put local unit tests under `src/test/java/com/kii/thingif`
- put instrumented unit tests under `src/androidTest/java/com/kii/thingif`
- put the test lib bot used in the above 2 tests under `src/testLib/java/com/kii/thingif`

### Improve circle ci configure script
- Remove unnecessary scripts
- Collect local unit tests report

### Implement EqualsClauseInTrigger and add tests
- implement `equals` and `toJSONObject` methods, and test in local unit tests `com.kii.thingif.trigger.EqualsClauseTest`
- test implement of Parcelable interface in instrumented tests `com.kii.thingif.trigger.ClauseParcelableTest`. 
