### PR TITLE
Implement trigger

### DIFF
--- a/thingif/src/main/java/com/kii/thingif/command/Command.java
+++ b/thingif/src/main/java/com/kii/thingif/command/Command.java
@@ -27,7 +27,7 @@ public class Command implements Parcelable {
     @SerializedName("actions")
     private final @NonNull List<AliasAction<? extends Action>> aliasActions;
     @SerializedName("actionResults")
-    private final @Nullable List<AliasActionResult> aliasActionResults;
+    private final @NonNull List<AliasActionResult> aliasActionResults;
     @SerializedName("commandState")
     private final @Nullable CommandState commandState;
     private final @Nullable String firedByTriggerID;
@@ -56,7 +56,11 @@ public class Command implements Parcelable {
         this.aliasActions = aliasActions;
         this.commandID = commandID;
         this.targetID = targetID;
-        this.aliasActionResults = aliasActionResults;
+        if (aliasActionResults != null) {
+            this.aliasActionResults = aliasActionResults;
+        }else {
+            this.aliasActionResults = new ArrayList<>();
+        }
         this.commandState = commandState;
         this.firedByTriggerID = firedByTriggerID;
         this.created = created;
@@ -126,7 +130,7 @@ public class Command implements Parcelable {
      * Get list of action result
      * @return action results of this command.
      */
-    @Nullable
+    @NonNull
     public List<AliasActionResult> getAliasActionResults() {
         return this.aliasActionResults;
     }
@@ -143,13 +147,11 @@ public class Command implements Parcelable {
             @NonNull String alias,
             @NonNull String actionName) {
         List<ActionResult> foundResults = new ArrayList<>();
-        if (this.aliasActionResults != null) {
-            for (AliasActionResult aliasResult : this.aliasActionResults) {
-                if (aliasResult.getAlias().equals(alias)) {
-                    for (ActionResult result : aliasResult.getResults()) {
-                        if (result.getActionName().equals(actionName)) {
-                            foundResults.add(result);
-                        }
+        for (AliasActionResult aliasResult : this.aliasActionResults) {
+            if (aliasResult.getAlias().equals(alias)) {
+                for (ActionResult result : aliasResult.getResults()) {
+                    if (result.getActionName().equals(actionName)) {
+                        foundResults.add(result);
                     }
                 }
             }
@@ -243,9 +245,6 @@ public class Command implements Parcelable {
         }
         if (this.issuerID == null) {
             throw new IllegalArgumentException("issuerID is null");
-        }
-        if (this.aliasActions == null || this.aliasActions.size() == 0) {
-            throw new IllegalArgumentException("actions is null or empty");
         }
     }
     public static final Creator<Command> CREATOR = new Creator<Command>() {

--- a/thingif/src/main/java/com/kii/thingif/trigger/Trigger.java
+++ b/thingif/src/main/java/com/kii/thingif/trigger/Trigger.java
@@ -3,6 +3,7 @@ package com.kii.thingif.trigger;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.kii.thingif.TypedID;
@@ -16,37 +17,37 @@ import org.json.JSONObject;
  */
 public class Trigger implements Parcelable {
 
-    private String triggerID;
-    private TypedID targetID;
-    private final Predicate predicate;
-    private final Command command;
-    private final ServerCode serverCode;
+    @NonNull private String triggerID;
+    @NonNull private TypedID targetID;
+    @NonNull private final Predicate predicate;
+    @Nullable private final Command command;
+    @Nullable private final ServerCode serverCode;
     private boolean disabled;
-    private String disabledReason;
-    private String title;
-    private String description;
-    private JSONObject metadata;
+    @Nullable private String disabledReason;
+    @Nullable private String title;
+    @Nullable private String description;
+    @Nullable private JSONObject metadata;
 
-    public Trigger(@NonNull Predicate predicate, @NonNull Command command) {
-        if (predicate == null) {
-            throw new IllegalArgumentException("predicate is null");
-        }
-        if (command == null) {
-            throw new IllegalArgumentException("command is null");
-        }
+    Trigger(
+            @NonNull String triggerID,
+            @NonNull TypedID targetID,
+            @NonNull Predicate predicate,
+            @Nullable Command command,
+            @Nullable ServerCode serverCode,
+            boolean disabled,
+            @Nullable String disabledReason,
+            @Nullable String title,
+            @Nullable String description,
+            @Nullable JSONObject metadata) {
+        this.triggerID = triggerID;
+        this.targetID = targetID;
         this.predicate = predicate;
         this.command = command;
-        this.serverCode = null;
-    }
-    public Trigger(@NonNull Predicate predicate, @NonNull ServerCode serverCode) {
-        if (predicate == null) {
-            throw new IllegalArgumentException("predicate is null");
-        }
-        if (serverCode == null) {
-            throw new IllegalArgumentException("serverCode is null");
-        }
-        this.predicate = predicate;
-        this.command = null;
+        this.disabled = disabled;
+        this.disabledReason = disabledReason;
+        this.title = title;
+        this.description = description;
+        this.metadata = metadata;
         this.serverCode = serverCode;
     }
 
@@ -54,6 +55,7 @@ public class Trigger implements Parcelable {
      * Get ID of the Trigger.
      * @return ID of the Trigger
      */
+    @NonNull
     public String getTriggerID() {
         return this.triggerID;
     }
@@ -64,6 +66,7 @@ public class Trigger implements Parcelable {
      * Target ID is determined by target bound to ThingIFAPI.
      * @return Target ID of Trigger.
      */
+    @NonNull
     public TypedID getTargetID() {
         return this.targetID;
     }
@@ -80,6 +83,7 @@ public class Trigger implements Parcelable {
      * Get Predicate of the Trigger.
      * @return Predicate of the Trigger
      */
+    @NonNull
     public Predicate getPredicate() {
         return this.predicate;
     }
@@ -88,6 +92,7 @@ public class Trigger implements Parcelable {
      * Get Command bounds to the Trigger.
      * @return Command  bounds to the Trigger.
      */
+    @Nullable
     public Command getCommand() {
         return this.command;
     }
@@ -96,6 +101,7 @@ public class Trigger implements Parcelable {
      * Get Server Code bounds to the Trigger.
      * @return Server Code bounds to the Trigger.
      */
+    @Nullable
     public ServerCode getServerCode() {
         return this.serverCode;
     }
@@ -117,6 +123,7 @@ public class Trigger implements Parcelable {
      * If #disabled is false, It returns null.
      * @return Reason of the Trigger has been disabled.
      */
+    @Nullable
     public String getDisabledReason() {
         return this.disabledReason;
     }
@@ -125,6 +132,7 @@ public class Trigger implements Parcelable {
      * Get title.
      * @return title of this trigger.
      */
+    @Nullable
     public String getTitle() {
         return this.title;
     }
@@ -132,6 +140,7 @@ public class Trigger implements Parcelable {
      * Get description.
      * @return description of this trigger.
      */
+    @Nullable
     public String getDescription() {
         return this.description;
     }
@@ -139,6 +148,7 @@ public class Trigger implements Parcelable {
      * Get meta data
      * @return meta data of this trigger.
      */
+    @Nullable
     public JSONObject getMetadata() {
         return this.metadata;
     }

--- a/thingif/src/test/java/com/kii/thingif/SmallTestBase.java
+++ b/thingif/src/test/java/com/kii/thingif/SmallTestBase.java
@@ -59,9 +59,9 @@ public class SmallTestBase {
         Assert.assertTrue(Arrays.equals(
                 expected.getAliasActions().toArray(),
                 actual.getAliasActions().toArray()));
-        Assert.assertFalse(
-                expected.getAliasActionResults() != null ^
-                actual.getAliasActionResults() != null );
+        Assert.assertTrue(
+                expected.getAliasActionResults() != null && actual.getAliasActionResults() != null ||
+                        expected.getAliasActionResults() == null && actual.getAliasActionResults() == null);
         if (expected.getAliasActionResults() != null && actual.getAliasActionResults() != null) {
             Assert.assertTrue(Arrays.equals(
                     expected.getAliasActionResults().toArray(),

--- a/thingif/src/test/java/com/kii/thingif/SmallTestBase.java
+++ b/thingif/src/test/java/com/kii/thingif/SmallTestBase.java
@@ -59,9 +59,13 @@ public class SmallTestBase {
         Assert.assertTrue(Arrays.equals(
                 expected.getAliasActions().toArray(),
                 actual.getAliasActions().toArray()));
-
-        Assert.assertTrue(Arrays.equals(
-                expected.getAliasActionResults().toArray(),
-                actual.getAliasActionResults().toArray()));
+        Assert.assertFalse(
+                expected.getAliasActionResults() != null ^
+                actual.getAliasActionResults() != null );
+        if (expected.getAliasActionResults() != null && actual.getAliasActionResults() != null) {
+            Assert.assertTrue(Arrays.equals(
+                    expected.getAliasActionResults().toArray(),
+                    actual.getAliasActionResults().toArray()));
+        }
     }
 }

--- a/thingif/src/test/java/com/kii/thingif/SmallTestBase.java
+++ b/thingif/src/test/java/com/kii/thingif/SmallTestBase.java
@@ -1,13 +1,17 @@
 package com.kii.thingif;
 
 
+import com.google.gson.Gson;
 import com.google.gson.JsonParser;
+import com.kii.thingif.command.Command;
 
 import junit.framework.Assert;
 
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import java.util.Arrays;
 
 public class SmallTestBase {
 
@@ -46,5 +50,18 @@ public class SmallTestBase {
                 Assert.assertEquals(e, a);
             }
         }
+    }
+
+    protected void assertSameCommands(Command expected, Command actual) {
+        Gson gson = new Gson();
+        Assert.assertEquals(gson.toJson(expected), gson.toJson(actual));
+
+        Assert.assertTrue(Arrays.equals(
+                expected.getAliasActions().toArray(),
+                actual.getAliasActions().toArray()));
+
+        Assert.assertTrue(Arrays.equals(
+                expected.getAliasActionResults().toArray(),
+                actual.getAliasActionResults().toArray()));
     }
 }

--- a/thingif/src/test/java/com/kii/thingif/actions/AirConditionerActions.java
+++ b/thingif/src/test/java/com/kii/thingif/actions/AirConditionerActions.java
@@ -30,8 +30,8 @@ public class AirConditionerActions implements Action {
         if (!(o instanceof AirConditionerActions)) return false;
         AirConditionerActions action = (AirConditionerActions)o;
         return this.power == action.power &&
-                this.presetTemperature == null?
+                (this.presetTemperature == null?
                 action.presetTemperature == null :
-                this.presetTemperature.equals(action.presetTemperature);
+                this.presetTemperature.equals(action.presetTemperature));
     }
 }

--- a/thingif/src/test/java/com/kii/thingif/actions/HumidityActions.java
+++ b/thingif/src/test/java/com/kii/thingif/actions/HumidityActions.java
@@ -14,4 +14,11 @@ public class HumidityActions implements Action {
     public Integer getPresetHumidity() {
         return presetHumidity;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null) return false;
+        if (!(o instanceof HumidityActions)) return false;
+        return this.presetHumidity.equals(((HumidityActions) o).getPresetHumidity());
+    }
 }

--- a/thingif/src/test/java/com/kii/thingif/command/CommandFactory.java
+++ b/thingif/src/test/java/com/kii/thingif/command/CommandFactory.java
@@ -1,0 +1,38 @@
+package com.kii.thingif.command;
+
+import com.kii.thingif.TypedID;
+
+import org.json.JSONObject;
+
+import java.util.List;
+
+public class CommandFactory {
+    public static Command newCommand(
+            TypedID issuerID,
+            List<AliasAction<? extends Action>> aliasActions,
+            String commandID,
+            TypedID targetID,
+            List<AliasActionResult> aliasActionResults,
+            CommandState commandState,
+            String firedByTriggerID,
+            Long created,
+            Long modified,
+            String title,
+            String description,
+            JSONObject metadata) {
+        return new Command(
+                issuerID,
+                aliasActions,
+                commandID,
+                targetID,
+                aliasActionResults,
+                commandState,
+                firedByTriggerID,
+                created,
+                modified,
+                title,
+                description,
+                metadata);
+    }
+
+}

--- a/thingif/src/test/java/com/kii/thingif/trigger/TriggerTest.java
+++ b/thingif/src/test/java/com/kii/thingif/trigger/TriggerTest.java
@@ -1,0 +1,185 @@
+package com.kii.thingif.trigger;
+
+import android.os.Parcel;
+
+import com.kii.thingif.SmallTestBase;
+import com.kii.thingif.TypedID;
+import com.kii.thingif.actions.AirConditionerActions;
+import com.kii.thingif.actions.HumidityActions;
+import com.kii.thingif.clause.trigger.EqualsClauseInTrigger;
+import com.kii.thingif.command.Action;
+import com.kii.thingif.command.AliasAction;
+import com.kii.thingif.command.Command;
+import com.kii.thingif.command.CommandFactory;
+
+import org.json.JSONObject;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@RunWith(RobolectricTestRunner.class)
+public class TriggerTest extends SmallTestBase{
+    private static final String alias1 = "AirConditionerAlias";
+    private static final String alias2 = "HumidityAlias";
+    @Test
+    public void commandTriggerTest() throws Exception {
+        TypedID target = new TypedID(TypedID.Types.THING, "thing1234");
+        TypedID issuer = new TypedID(TypedID.Types.USER, "user1234");
+
+        List<AliasAction<? extends Action>> actions = new ArrayList<>();
+        actions.add(new AliasAction<Action>(
+                alias1,
+                new AirConditionerActions(true, null)));
+        actions.add(new AliasAction<Action>(
+                alias2,
+                new HumidityActions(45)));
+        String commandTitle = "command title";
+        String commandDescription = "command description";
+        JSONObject commandMetaData = new JSONObject().put("k", "v");
+        Command command = CommandFactory.newCommand(
+                issuer,
+                actions,
+                null,
+                target,
+                null,
+                null,
+                null,
+                null,
+                null,
+                commandTitle,
+                commandDescription,
+                commandMetaData);
+
+        EqualsClauseInTrigger equals = new EqualsClauseInTrigger(alias1, "power", true);
+        Condition condition = new Condition(equals);
+        StatePredicate predicate = new StatePredicate(condition, TriggersWhen.CONDITION_TRUE);
+
+        String triggerID = "trigger1234";
+        boolean disabled = true;
+        String disabledReason = "reasonXXXX";
+        String title = "Title of Trigger";
+        String description = "Description of Trigger";
+        JSONObject metadata = new JSONObject();
+        metadata.put("sound", "phone.mp3");
+
+        Trigger trigger = new Trigger(
+                triggerID,
+                target,
+                predicate,
+                command,
+                null,
+                disabled,
+                disabledReason,
+                title,
+                description,
+                metadata);
+
+        Assert.assertEquals(triggerID, trigger.getTriggerID());
+        Assert.assertEquals(target, trigger.getTargetID());
+        Assert.assertTrue(trigger.getPredicate() instanceof StatePredicate);
+        Assert.assertEquals(equals, ((StatePredicate)trigger.getPredicate()).getCondition().getClause());
+        assertSameCommands(command, trigger.getCommand());
+        Assert.assertNull(trigger.getServerCode());
+        Assert.assertEquals(disabled, trigger.disabled());
+        Assert.assertEquals(disabledReason, trigger.getDisabledReason());
+        Assert.assertEquals(title, trigger.getTitle());
+        Assert.assertEquals(description, trigger.getDescription());
+        assertJSONObject(metadata, trigger.getMetadata());
+
+        Parcel parcel = Parcel.obtain();
+        trigger.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+        Trigger deserializedTrigger = Trigger.CREATOR.createFromParcel(parcel);
+
+        Assert.assertNull(deserializedTrigger.getServerCode());
+        assertSameCommands(trigger.getCommand(), deserializedTrigger.getCommand());
+
+        Assert.assertEquals(equals, ((StatePredicate)deserializedTrigger.getPredicate()).getCondition().getClause());
+        Assert.assertEquals(TriggersWhen.CONDITION_TRUE, ((StatePredicate) deserializedTrigger.getPredicate()).getTriggersWhen());
+
+        Assert.assertEquals(triggerID, deserializedTrigger.getTriggerID());
+        Assert.assertEquals(disabled, deserializedTrigger.disabled());
+        Assert.assertEquals(disabledReason, deserializedTrigger.getDisabledReason());
+        Assert.assertEquals(title, deserializedTrigger.getTitle());
+        Assert.assertEquals(description, deserializedTrigger.getDescription());
+        assertJSONObject(metadata, deserializedTrigger.getMetadata());
+        Assert.assertEquals(TriggersWhat.COMMAND, deserializedTrigger.getTriggersWhat());
+    }
+    @Test
+    public void serverCodeTriggerTest() throws Exception {
+        TypedID target = new TypedID(TypedID.Types.THING, "thing1234");
+
+        String endpoint = "function_name";
+        String executorAccessToken = UUID.randomUUID().toString();
+        String targetAppID = UUID.randomUUID().toString().substring(0, 8);
+        JSONObject parameters = new JSONObject("{\"name\":\"kii\", \"age\":30, \"enabled\":true}");
+        ServerCode serverCode = new ServerCode(endpoint, executorAccessToken, targetAppID, parameters);
+
+        EqualsClauseInTrigger equals = new EqualsClauseInTrigger(alias1, "power", true);
+        Condition condition = new Condition(equals);
+        StatePredicate predicate = new StatePredicate(condition, TriggersWhen.CONDITION_TRUE);
+
+        String triggerID = "trigger1234";
+        boolean disabled = true;
+        String disabledReason = "reasonXXXX";
+        String title = "Title of Trigger";
+        String description = "Description of Trigger";
+        JSONObject metadata = new JSONObject();
+        metadata.put("sound", "phone.mp3");
+
+        Trigger trigger = new Trigger(
+                triggerID,
+                target,
+                predicate,
+                null,
+                serverCode,
+                disabled,
+                disabledReason,
+                title,
+                description,
+                metadata);
+
+        Assert.assertEquals(triggerID, trigger.getTriggerID());
+        Assert.assertEquals(target, trigger.getTargetID());
+        Assert.assertTrue(trigger.getPredicate() instanceof StatePredicate);
+        Assert.assertEquals(equals, ((StatePredicate)trigger.getPredicate()).getCondition().getClause());
+        Assert.assertNull(trigger.getCommand());
+        Assert.assertNotNull(trigger.getServerCode());
+        Assert.assertEquals(endpoint, trigger.getServerCode().getEndpoint());
+        Assert.assertEquals(executorAccessToken, trigger.getServerCode().getExecutorAccessToken());
+        Assert.assertEquals(targetAppID, trigger.getServerCode().getTargetAppID());
+        assertJSONObject(parameters, trigger.getServerCode().getParameters());
+        Assert.assertEquals(disabled, trigger.disabled());
+        Assert.assertEquals(disabledReason, trigger.getDisabledReason());
+        Assert.assertEquals(title, trigger.getTitle());
+        Assert.assertEquals(description, trigger.getDescription());
+        assertJSONObject(metadata, trigger.getMetadata());
+
+        Parcel parcel = Parcel.obtain();
+        trigger.writeToParcel(parcel, 0);
+        parcel.setDataPosition(0);
+        Trigger deserializedTrigger = Trigger.CREATOR.createFromParcel(parcel);
+
+        Assert.assertNull(deserializedTrigger.getCommand());
+        Assert.assertEquals(endpoint, deserializedTrigger.getServerCode().getEndpoint());
+        Assert.assertEquals(executorAccessToken, deserializedTrigger.getServerCode().getExecutorAccessToken());
+        Assert.assertEquals(targetAppID, deserializedTrigger.getServerCode().getTargetAppID());
+        assertJSONObject(parameters, deserializedTrigger.getServerCode().getParameters());
+
+        Assert.assertEquals(equals, ((StatePredicate)deserializedTrigger.getPredicate()).getCondition().getClause());
+        Assert.assertEquals(TriggersWhen.CONDITION_TRUE, ((StatePredicate) deserializedTrigger.getPredicate()).getTriggersWhen());
+
+        Assert.assertEquals(triggerID, deserializedTrigger.getTriggerID());
+        Assert.assertEquals(disabled, deserializedTrigger.disabled());
+        Assert.assertEquals(disabledReason, deserializedTrigger.getDisabledReason());
+        Assert.assertEquals(title, deserializedTrigger.getTitle());
+        Assert.assertEquals(description, deserializedTrigger.getDescription());
+        assertJSONObject(metadata, deserializedTrigger.getMetadata());
+        Assert.assertTrue(deserializedTrigger.getTriggersWhat().equals(TriggersWhat.SERVER_CODE));
+    }
+}


### PR DESCRIPTION
- Improve implementation of Command. Found problem of implementation of Command for aliasActionResults. The problem is when aliasActionResults array is null, after deserialized from Parcel, it become non null. 
- Make constructor of Trigger package private. Since SDK construct trigger using Gson, developer should not construct trigger by themselves. 
- Add small tests for Trigger. 