### PR TITLE
Add transient to cached hashCode

### DIFF
--- a/thingif/src/main/java/com/kii/thingif/clause/query/EqualsClauseInQuery.java
+++ b/thingif/src/main/java/com/kii/thingif/clause/query/EqualsClauseInQuery.java
@@ -11,7 +11,7 @@ public class EqualsClauseInQuery implements BaseEquals, QueryClause {
     private @NonNull String field;
     private @NonNull Object value;
 
-    private volatile int hashCode; // cached hashcode for performance
+    private transient volatile int hashCode; // cached hashcode for performance
 
     public EqualsClauseInQuery(
             @NonNull String field,

--- a/thingif/src/main/java/com/kii/thingif/clause/query/NotEqualsClauseInQuery.java
+++ b/thingif/src/main/java/com/kii/thingif/clause/query/NotEqualsClauseInQuery.java
@@ -10,7 +10,7 @@ public class NotEqualsClauseInQuery implements BaseNotEquals, QueryClause {
 
     private EqualsClauseInQuery equals;
 
-    private volatile int hashCode; // cached hashcode for performance
+    private transient volatile int hashCode; // cached hashcode for performance
 
     public NotEqualsClauseInQuery(EqualsClauseInQuery equals) {
         this.equals = equals;

--- a/thingif/src/main/java/com/kii/thingif/clause/query/RangeClauseInQuery.java
+++ b/thingif/src/main/java/com/kii/thingif/clause/query/RangeClauseInQuery.java
@@ -15,7 +15,7 @@ public class RangeClauseInQuery implements QueryClause, BaseRange {
     private @Nullable Boolean upperIncluded;
     private @Nullable Boolean lowerIncluded;
 
-    private volatile int hashCode; // cached hashcode for performance
+    private transient volatile int hashCode; // cached hashcode for performance
 
     private RangeClauseInQuery(
             @NonNull String field,

--- a/thingif/src/main/java/com/kii/thingif/clause/trigger/NotEqualsClauseInTrigger.java
+++ b/thingif/src/main/java/com/kii/thingif/clause/trigger/NotEqualsClauseInTrigger.java
@@ -11,7 +11,7 @@ import org.json.JSONObject;
 public class NotEqualsClauseInTrigger implements BaseNotEquals, TriggerClause {
     private EqualsClauseInTrigger equals;
 
-    private volatile int hashCode; // cached hashcode for performance
+    private transient volatile int hashCode; // cached hashcode for performance
 
     public NotEqualsClauseInTrigger(EqualsClauseInTrigger equals) {
         this.equals = equals;

--- a/thingif/src/main/java/com/kii/thingif/command/ActionResult.java
+++ b/thingif/src/main/java/com/kii/thingif/command/ActionResult.java
@@ -18,7 +18,7 @@ public final class ActionResult implements Parcelable {
     @NonNull private String actionName;
     @Nullable private JSONObject data;
 
-    private volatile int hashCode; // cached hashcode for performance
+    private transient volatile int hashCode; // cached hashcode for performance
 
     ActionResult(
             @NonNull String actionName,

--- a/thingif/src/main/java/com/kii/thingif/command/AliasAction.java
+++ b/thingif/src/main/java/com/kii/thingif/command/AliasAction.java
@@ -15,7 +15,7 @@ public class AliasAction<T extends Action> implements Parcelable{
     @NonNull private String alias;
     @NonNull private T action;
 
-    private volatile int hashCode; // cached hashcode for performance
+    private transient volatile int hashCode; // cached hashcode for performance
 
     /**
      * Initialize AliasAction instance.

--- a/thingif/src/main/java/com/kii/thingif/command/AliasActionResult.java
+++ b/thingif/src/main/java/com/kii/thingif/command/AliasActionResult.java
@@ -16,7 +16,7 @@ public class AliasActionResult implements Parcelable{
     @NonNull private String alias;
     @NonNull private List<ActionResult> results;
 
-    private volatile int hashCode; // cached hashcode for performance
+    private transient volatile int hashCode; // cached hashcode for performance
 
     AliasActionResult(
             @NonNull String alias,

--- a/thingif/src/main/java/com/kii/thingif/query/AggregatedResult.java
+++ b/thingif/src/main/java/com/kii/thingif/query/AggregatedResult.java
@@ -15,7 +15,7 @@ public class AggregatedResult<T extends Number, S extends TargetState> implement
     private @NonNull T value;
     private @Nullable List<HistoryState<S>> aggregatedObjects;
 
-    private volatile int hashCode; // cached hashcode for performance
+    private transient volatile int hashCode; // cached hashcode for performance
 
     AggregatedResult(
         @NonNull TimeRange timeRange,

--- a/thingif/src/main/java/com/kii/thingif/query/Aggregation.java
+++ b/thingif/src/main/java/com/kii/thingif/query/Aggregation.java
@@ -15,7 +15,7 @@ public class Aggregation implements Parcelable{
     private @NonNull final String field;
     private @NonNull final FieldType fieldType;
 
-    private volatile int hashCode; // cached hashcode for performance
+    private transient volatile int hashCode; // cached hashcode for performance
 
     public static enum FunctionType{
         MAX,

--- a/thingif/src/main/java/com/kii/thingif/query/GroupedHistoryStates.java
+++ b/thingif/src/main/java/com/kii/thingif/query/GroupedHistoryStates.java
@@ -14,7 +14,7 @@ public class GroupedHistoryStates<S extends TargetState> implements Parcelable {
     private @NonNull TimeRange timeRange;
     private @NonNull List<HistoryState<S>> objects;
 
-    private volatile int hashCode; // cached hashcode for performance
+    private transient volatile int hashCode; // cached hashcode for performance
 
     public GroupedHistoryStates(
             @NonNull TimeRange timeRange,

--- a/thingif/src/main/java/com/kii/thingif/query/GroupedHistoryStatesQuery.java
+++ b/thingif/src/main/java/com/kii/thingif/query/GroupedHistoryStatesQuery.java
@@ -15,7 +15,7 @@ public class GroupedHistoryStatesQuery implements Parcelable {
     private @Nullable String firmwareVersion;
     private @NonNull TimeRange timeRange;
 
-    private volatile int hashCode; // cached hashcode for performance
+    private transient volatile int hashCode; // cached hashcode for performance
 
     private GroupedHistoryStatesQuery(
             @NonNull String alias,

--- a/thingif/src/main/java/com/kii/thingif/query/HistoryState.java
+++ b/thingif/src/main/java/com/kii/thingif/query/HistoryState.java
@@ -12,7 +12,7 @@ public class HistoryState<T extends TargetState> implements Parcelable {
     private @NonNull T state;
     private @NonNull Date createdAt;
 
-    private volatile int hashCode; // cached hashcode for performance
+    private transient volatile int hashCode; // cached hashcode for performance
 
     public HistoryState(
             @NonNull T state,

--- a/thingif/src/main/java/com/kii/thingif/query/HistoryStatesQuery.java
+++ b/thingif/src/main/java/com/kii/thingif/query/HistoryStatesQuery.java
@@ -15,7 +15,7 @@ public class HistoryStatesQuery implements Parcelable {
     private @Nullable Integer bestEffortLimit;
     private @Nullable String nextPaginationKey;
 
-    private volatile int hashCode; // cached hashcode for performance
+    private transient volatile int hashCode; // cached hashcode for performance
 
     private HistoryStatesQuery(
             @NonNull  String alias,

--- a/thingif/src/main/java/com/kii/thingif/query/TimeRange.java
+++ b/thingif/src/main/java/com/kii/thingif/query/TimeRange.java
@@ -11,7 +11,7 @@ public class TimeRange implements Parcelable{
     private @NonNull Date from;
     private @NonNull Date to;
 
-    private volatile int hashCode; // cached hashcode for performance
+    private transient volatile int hashCode; // cached hashcode for performance
 
     /**
      * Initialize time range.


### PR DESCRIPTION
Found the problem in #231 , where when serialize EqualsClauseInTrigger instance using Gson, hashCode is put into result json. 

In these classes, use `hashCode` attribute to cached the calculated hashCode by `hashCode` method. However, this attribute is not part of business model, should not be serialized. Add transient keyword to hashCode attribute to ignore it when serializing the instances of these classes. 