### PR TITLE
Override post patch trigger

### DIFF
--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -1174,7 +1174,7 @@ public class ThingIFAPI implements Parcelable {
      * more following conditions are met.
      * <ul>
      *  <li>triggerID is null or empty string.</li>
-     *  <li>All of form, predicate and options are null</li>
+     *  <li>All of form, predicate and options are null.</li>
      * </ul>
      */
     @NonNull
@@ -1188,7 +1188,39 @@ public class ThingIFAPI implements Parcelable {
     {
         return patchTriggerWithForm(triggerID, form, predicate, options);
     }
-    
+
+    /**
+     * Apply patch to registered trigger.
+     * Modify registered trigger with specified patch.
+     * <p>
+     * Limited version of {@link #patchTrigger(String, TriggeredCommandForm, Predicate, TriggerOptions)}
+     * <p>
+     * @param triggerID ID of the trigger to apply patch.
+     * @param form Form of triggered command. It contains name of schema,
+     * version of schema, list of actions, target IDof thing etc. You can see
+     * detail of form in {@link TriggeredCommandForm}.
+     * @param predicate Modified predicate.
+     * @return Updated trigger instance.
+     * @throws ThingIFException Thrown when failed to connect IoT Cloud Server.
+     * @throws ThingIFRestException Thrown when server returns error response.
+     * @throws IllegalArgumentException This exception is thrown if one or
+     * more following conditions are met.
+     * <ul>
+     *  <li>triggerID is null or empty string.</li>
+     *  <li>both form and predicate are null.</li>
+     * </ul>
+     */
+    @NonNull
+    @WorkerThread
+    public Trigger patchTrigger(
+            @NonNull String triggerID,
+            @Nullable TriggeredCommandForm form,
+            @Nullable Predicate predicate)
+            throws ThingIFException
+    {
+        return patchTriggerWithForm(triggerID, form, predicate, null);
+    }
+
     @NonNull
     @WorkerThread
     private Trigger patchTriggerWithForm(

--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -980,7 +980,7 @@ public class ThingIFAPI implements Parcelable {
      * @return Instance of the Trigger registered in IoT Cloud.
      * @throws ThingIFException Thrown when failed to connect IoT Cloud Server.
      * @throws ThingIFRestException Thrown when server returns error response.
-     * @throws IllegalArgumentException if form and/or predicate is null.
+     * @throws IllegalArgumentException if any of form, predicate and options is/are null.
      */
     @NonNull
     @WorkerThread
@@ -993,6 +993,39 @@ public class ThingIFAPI implements Parcelable {
         return postNewTriggerWithForm(form, predicate, options);
     }
 
+    /**
+     * Post new Trigger with commands to IoT Cloud.
+     *
+     * <p>
+     * When thing retrieved by {@link #getTarget()} of this ThingIFAPI
+     * instance meets condition described by predicate, A command registered
+     * by {@link TriggeredCommandForm} sends to thing given by {@link
+     * TriggeredCommandForm#getTargetID()}.
+     * </p>
+     * Limited version of {@link #postNewTrigger(TriggeredCommandForm, Predicate, TriggerOptions)}
+     * <p>
+     * {@link #getTarget()} instance and thing specified by {@link
+     * TriggeredCommandForm#getTargetID()} must be same owner's things.
+     * </p>
+     *
+     * @param form Form of triggered command. It contains name of schema,
+     * version of schema, list of actions, target IDof thing etc. You can see
+     * detail of form in {@link TriggeredCommandForm}.
+     * @param predicate Specify when the Trigger fires command.
+     * @return Instance of the Trigger registered in IoT Cloud.
+     * @throws ThingIFException Thrown when failed to connect IoT Cloud Server.
+     * @throws ThingIFRestException Thrown when server returns error response.
+     * @throws IllegalArgumentException if any of form and predicate is/are null.
+     */
+    @NonNull
+    @WorkerThread
+    public Trigger postNewTrigger(
+            @NonNull TriggeredCommandForm form,
+            @NonNull Predicate predicate)
+            throws ThingIFException
+    {
+        return postNewTriggerWithForm(form, predicate, null);
+    }
     private Trigger postNewTriggerWithForm(
             @NonNull TriggeredCommandForm form,
             @NonNull Predicate predicate,
@@ -1039,6 +1072,7 @@ public class ThingIFAPI implements Parcelable {
      * @return Instance of the Trigger registered in IoT Cloud.
      * @throws ThingIFException Thrown when failed to connect IoT Cloud Server.
      * @throws ThingIFRestException Thrown when server returns error response.
+     * @throws IllegalArgumentException if any of serverCode, predicate and options is/are null.
      */
     @NonNull
     @WorkerThread
@@ -1065,6 +1099,7 @@ public class ThingIFAPI implements Parcelable {
      * @return Instance of the Trigger registered in IoT Cloud.
      * @throws ThingIFException Thrown when failed to connect IoT Cloud Server.
      * @throws ThingIFRestException Thrown when server returns error response.
+     * @throws IllegalArgumentException if any of serverCode and predicate is/are null.
      */
     @NonNull
     @WorkerThread
@@ -1282,8 +1317,12 @@ public class ThingIFAPI implements Parcelable {
      * @return Updated Trigger instance.
      * @throws ThingIFException Thrown when failed to connect IoT Cloud Server.
      * @throws ThingIFRestException Thrown when server returns error response.
-     * @throws IllegalArgumentException when all of  serverCode, predicates
-     * and options are null.
+     * @throws IllegalArgumentException This exception is thrown if one or
+     * more following conditions are met.
+     * <ul>
+     *  <li>triggerID is null or empty string.</li>
+     *  <li>all of serverCode, predicate and options are null.</li>
+     * </ul>
      */
     @NonNull
     @WorkerThread
@@ -1315,8 +1354,12 @@ public class ThingIFAPI implements Parcelable {
      * @return Updated Trigger instance.
      * @throws ThingIFException Thrown when failed to connect IoT Cloud Server.
      * @throws ThingIFRestException Thrown when server returns error response.
-     * @throws IllegalArgumentException when both server and predicates are
-     * null.
+     * @throws IllegalArgumentException This exception is thrown if one or
+     * more following conditions are met.
+     * <ul>
+     *  <li>triggerID is null or empty string.</li>
+     *  <li>both serverCode and predicate are null.</li>
+     * </ul>
      */
     @NonNull
     @WorkerThread

--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -1186,6 +1186,18 @@ public class ThingIFAPI implements Parcelable {
             @Nullable TriggerOptions options)
         throws ThingIFException
     {
+        return patchTriggerWithForm(triggerID, form, predicate, options);
+    }
+    
+    @NonNull
+    @WorkerThread
+    private Trigger patchTriggerWithForm(
+            @NonNull String triggerID,
+            @Nullable TriggeredCommandForm form,
+            @Nullable Predicate predicate,
+            @Nullable TriggerOptions options)
+        throws ThingIFException
+    {
         if (this.target == null) {
             throw new IllegalStateException(
                 "Can not perform this action before onboarding");

--- a/thingif/src/test/java/com/kii/thingif/thingifapi/PatchTriggerTest.java
+++ b/thingif/src/test/java/com/kii/thingif/thingifapi/PatchTriggerTest.java
@@ -149,7 +149,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
                 false,
                 null);
 
-        Trigger trigger = this.defaultApi.patchTrigger(triggerID, form, predicate, options);
+        Trigger trigger = this.defaultApi.patchCommandTrigger(triggerID, form, predicate, options);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(false, trigger.disabled());
@@ -226,7 +226,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
                 false,
                 null);
 
-        Trigger trigger = this.defaultApi.patchTrigger(triggerID, form, predicate, options);
+        Trigger trigger = this.defaultApi.patchCommandTrigger(triggerID, form, predicate, options);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(false, trigger.disabled());
@@ -306,7 +306,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
                 false,
                 null);
 
-        Trigger trigger = this.defaultApi.patchTrigger(triggerID, form, predicate, options);
+        Trigger trigger = this.defaultApi.patchCommandTrigger(triggerID, form, predicate, options);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(false, trigger.disabled());
@@ -382,7 +382,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
                 false,
                 null);
 
-        Trigger trigger = this.defaultApi.patchTrigger(triggerID, form, null, options);
+        Trigger trigger = this.defaultApi.patchCommandTrigger(triggerID, form, null, options);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(false, trigger.disabled());
@@ -445,7 +445,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
                 false,
                 null);
 
-        Trigger trigger = this.defaultApi.patchTrigger(triggerID, (TriggeredCommandForm) null, predicate, options);
+        Trigger trigger = this.defaultApi.patchCommandTrigger(triggerID, null, predicate, options);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(false, trigger.disabled());
@@ -515,7 +515,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
                 false,
                 null);
 
-        Trigger trigger = this.defaultApi.patchTrigger(triggerID, form, predicate, null);
+        Trigger trigger = this.defaultApi.patchCommandTrigger(triggerID, form, predicate, null);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(false, trigger.disabled());
@@ -567,7 +567,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
         this.addEmptyMockResponse(403);
 
         try {
-            this.defaultApi.patchTrigger("trigger-1234", form, predicate, null);
+            this.defaultApi.patchCommandTrigger("trigger-1234", form, predicate, null);
             Assert.fail("ThingIFRestException should be thrown");
         } catch (ForbiddenException e) {
         }
@@ -602,7 +602,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
         this.addEmptyMockResponse(404);
 
         try {
-            this.defaultApi.patchTrigger("trigger-1234", form, predicate, null);
+            this.defaultApi.patchCommandTrigger("trigger-1234", form, predicate, null);
             Assert.fail("ThingIFRestException should be thrown");
         } catch (NotFoundException e) {
         }
@@ -637,7 +637,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
         this.addEmptyMockResponse(503);
 
         try {
-            this.defaultApi.patchTrigger("trigger-1234", form, predicate, null);
+            this.defaultApi.patchCommandTrigger("trigger-1234", form, predicate, null);
             Assert.fail("ThingIFRestException should be thrown");
         } catch (ServiceUnavailableException e) {
         }
@@ -663,19 +663,19 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
     // call patchTrigger(String, TriggeredCommandForm, Predicate, TriggerOptions)
     public void patchCommandTriggerWithNullTargetTest() throws Exception {
         ThingIFAPI api = this.createDefaultThingIFAPI(this.context, APP_ID, APP_KEY);
-        api.patchTrigger("trigger-1234", getDefaultForm(), getDefaultPredicate(), getDefaultOptions());
+        api.patchCommandTrigger("trigger-1234", getDefaultForm(), getDefaultPredicate(), getDefaultOptions());
     }
 
     @Test(expected = IllegalArgumentException.class)
     // call patchTrigger(String, null, null, null)
     public void patchCommandTrigger_NullForm_NullPredicate_NullOptions_Test() throws Exception{
-        this.defaultApi.patchTrigger("trigger-1234", (TriggeredCommandForm)null, null, null);
+        this.defaultApi.patchCommandTrigger("trigger-1234", null, null, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     // call patchTrigger(null, TriggeredCommandForm, Predicate, TriggerOptions)
     public void patchCommandTrigger_NullTriggerID_Form_Predicate_Options_Test() throws Exception{
-        this.defaultApi.patchTrigger(
+        this.defaultApi.patchCommandTrigger(
                 null,
                 getDefaultForm(),
                 getDefaultPredicate(),
@@ -685,7 +685,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
     @Test(expected = IllegalArgumentException.class)
     // call patchTrigger("", TriggeredCommandForm, Predicate, TriggerOptions)
     public void patchCommandTrigger_EmptyTriggerID_Form_Predicate_Options_Test() throws Exception{
-        this.defaultApi.patchTrigger(
+        this.defaultApi.patchCommandTrigger(
                 "",
                 getDefaultForm(),
                 getDefaultPredicate(),
@@ -704,7 +704,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
         this.addMockResponseForGetTriggerWithServerCode(200, triggerID, serverCode, predicate, options, false, null);
 
         Trigger trigger;
-        trigger = this.defaultApi.patchTrigger(triggerID, serverCode, predicate, options);
+        trigger = this.defaultApi.patchServerCodeTrigger(triggerID, serverCode, predicate, options);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(false, trigger.disabled());
@@ -758,7 +758,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
         this.addMockResponseForGetTriggerWithServerCode(200, triggerID, serverCode, predicate, options, false, null);
 
         Trigger trigger;
-        trigger = this.defaultApi.patchTrigger(triggerID, serverCode, predicate, options);
+        trigger = this.defaultApi.patchServerCodeTrigger(triggerID, serverCode, predicate, options);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(false, trigger.disabled());
@@ -811,7 +811,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
         this.addMockResponseForGetTriggerWithServerCode(200, triggerID, serverCode, predicate, options, false, null);
 
         Trigger trigger;
-        trigger = this.defaultApi.patchTrigger(triggerID, serverCode, predicate, options);
+        trigger = this.defaultApi.patchServerCodeTrigger(triggerID, serverCode, predicate, options);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(false, trigger.disabled());
@@ -864,7 +864,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
         this.addMockResponseForGetTriggerWithServerCode(200, triggerID, serverCode, predicate, null, false, null);
 
         Trigger trigger;
-        trigger = this.defaultApi.patchTrigger(triggerID, serverCode, predicate, null);
+        trigger = this.defaultApi.patchServerCodeTrigger(triggerID, serverCode, predicate, null);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(false, trigger.disabled());
@@ -922,7 +922,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
                 null);
 
         Trigger trigger;
-        trigger = this.defaultApi.patchTrigger(triggerID, (ServerCode) null, predicate, options);
+        trigger = this.defaultApi.patchServerCodeTrigger(triggerID, (ServerCode) null, predicate, options);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(false, trigger.disabled());
@@ -980,7 +980,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
                 null);
 
         Trigger trigger;
-        trigger = this.defaultApi.patchTrigger(
+        trigger = this.defaultApi.patchServerCodeTrigger(
                 triggerID,
                 getDefaultServerCode(),
                 null,
@@ -1042,7 +1042,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
                 null);
 
         Trigger trigger;
-        trigger = this.defaultApi.patchTrigger(
+        trigger = this.defaultApi.patchServerCodeTrigger(
                 triggerID,
                 (ServerCode) null,
                 null,
@@ -1091,7 +1091,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
     // call patchTrigger(String, ServerCode, Predicate, TriggerOptions)
     public void patchServerCodeTrigger_NullOptions_WithNullTargetTest() throws Exception {
         ThingIFAPI api = this.createDefaultThingIFAPI(this.context, APP_ID, APP_KEY);
-        api.patchTrigger(
+        api.patchServerCodeTrigger(
                 "trigger-1234",
                 getDefaultServerCode(),
                 getDefaultPredicate(),
@@ -1108,13 +1108,13 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
 
         ThingIFAPI api = this.createDefaultThingIFAPI(this.context, APP_ID, APP_KEY);
         ThingIFAPIUtils.setTarget(api, target);
-        api.patchTrigger("trigger-1234", (ServerCode) null, null, null);
+        api.patchServerCodeTrigger("trigger-1234", (ServerCode) null, null, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     // call patchTrigger(null, ServerCode, Predicate, TriggerOptions)
     public void patchServerCodeTrigger_NullTriggerID_NonNullOptions_ServerCode_Predicate_Test() throws Exception{
-        this.defaultApi.patchTrigger(
+        this.defaultApi.patchServerCodeTrigger(
                 null,
                 getDefaultServerCode(),
                 getDefaultPredicate(),
@@ -1124,7 +1124,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
     @Test(expected = IllegalArgumentException.class)
     // call patchTrigger("", ServerCode, Predicate, TriggerOptions)
     public void patchServerCodeTrigger_EmptyTriggerID_NonNullOptions_ServerCode_Predicate_Test() throws Exception{
-        this.defaultApi.patchTrigger(
+        this.defaultApi.patchServerCodeTrigger(
                 "",
                 getDefaultServerCode(),
                 getDefaultPredicate(),
@@ -1140,7 +1140,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
         this.addEmptyMockResponse(404);
 
         try {
-            this.defaultApi.patchTrigger("trigger-1234", expectedServerCode, predicate);
+            this.defaultApi.patchServerCodeTrigger("trigger-1234", expectedServerCode, predicate);
             Assert.fail("ThingIFRestException should be thrown");
         } catch (NotFoundException e) {
         }
@@ -1173,7 +1173,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
         this.addEmptyMockResponse(503);
 
         try {
-            this.defaultApi.patchTrigger("trigger-1234", expectedServerCode, predicate);
+            this.defaultApi.patchServerCodeTrigger("trigger-1234", expectedServerCode, predicate);
             Assert.fail("ThingIFRestException should be thrown");
         } catch (ServiceUnavailableException e) {
         }
@@ -1211,7 +1211,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
         this.addMockResponseForGetTriggerWithServerCode(200, triggerID, serverCode, predicate, options, false, null);
 
         Trigger trigger;
-        trigger = this.defaultApi.patchTrigger(triggerID, serverCode, predicate);
+        trigger = this.defaultApi.patchServerCodeTrigger(triggerID, serverCode, predicate);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(false, trigger.disabled());
@@ -1262,7 +1262,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
         this.addMockResponseForGetTriggerWithServerCode(200, triggerID, serverCode, predicate, options, false, null);
 
         Trigger trigger;
-        trigger = this.defaultApi.patchTrigger(triggerID, serverCode, predicate);
+        trigger = this.defaultApi.patchServerCodeTrigger(triggerID, serverCode, predicate);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(false, trigger.disabled());
@@ -1312,7 +1312,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
         this.addMockResponseForGetTriggerWithServerCode(200, triggerID, serverCode, predicate, options, false, null);
 
         Trigger trigger;
-        trigger = this.defaultApi.patchTrigger(triggerID, serverCode, predicate);
+        trigger = this.defaultApi.patchServerCodeTrigger(triggerID, serverCode, predicate);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(false, trigger.disabled());
@@ -1370,7 +1370,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
                 null);
 
         Trigger trigger;
-        trigger = this.defaultApi.patchTrigger(triggerID, (ServerCode) null, predicate);
+        trigger = this.defaultApi.patchServerCodeTrigger(triggerID, (ServerCode) null, predicate);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(false, trigger.disabled());
@@ -1425,7 +1425,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
                 null);
 
         Trigger trigger;
-        trigger = this.defaultApi.patchTrigger(
+        trigger = this.defaultApi.patchServerCodeTrigger(
                 triggerID,
                 getDefaultServerCode(),
                 null);
@@ -1470,7 +1470,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
     // call patchTrigger(String, ServerCode, Predicate)
     public void patchServerCodeTrigger_WithNullTargetTest() throws Exception {
         ThingIFAPI api = this.createDefaultThingIFAPI(this.context, APP_ID, APP_KEY);
-        api.patchTrigger(
+        api.patchServerCodeTrigger(
                 "trigger-1234",
                 getDefaultServerCode(),
                 getDefaultPredicate());
@@ -1486,13 +1486,13 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
 
         ThingIFAPI api = this.createDefaultThingIFAPI(this.context, APP_ID, APP_KEY);
         ThingIFAPIUtils.setTarget(api, target);
-        api.patchTrigger("trigger-1234", (ServerCode) null, null);
+        api.patchServerCodeTrigger("trigger-1234", (ServerCode) null, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     // call patchTrigger(null, ServerCode, Predicate)
     public void patchServerCodeTrigger_NullTriggerID_ServerCode_Predicate_Test() throws Exception{
-        this.defaultApi.patchTrigger(
+        this.defaultApi.patchServerCodeTrigger(
                 null,
                 getDefaultServerCode(),
                 getDefaultPredicate());
@@ -1501,7 +1501,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
     @Test(expected = IllegalArgumentException.class)
     // call patchTrigger("", ServerCode, Predicate)
     public void patchServerCodeTrigger_EmptyTriggerID_ServerCode_Predicate_Test() throws Exception{
-        this.defaultApi.patchTrigger(
+        this.defaultApi.patchServerCodeTrigger(
                 "",
                 getDefaultServerCode(),
                 getDefaultPredicate());
@@ -1516,7 +1516,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
         this.addEmptyMockResponse(404);
 
         try {
-            this.defaultApi.patchTrigger("trigger-1234", expectedServerCode, predicate);
+            this.defaultApi.patchServerCodeTrigger("trigger-1234", expectedServerCode, predicate);
             Assert.fail("ThingIFRestException should be thrown");
         } catch (NotFoundException e) {
         }
@@ -1549,7 +1549,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
         this.addEmptyMockResponse(503);
 
         try {
-            this.defaultApi.patchTrigger("trigger-1234", expectedServerCode, predicate);
+            this.defaultApi.patchServerCodeTrigger("trigger-1234", expectedServerCode, predicate);
             Assert.fail("ThingIFRestException should be thrown");
         } catch (ServiceUnavailableException e) {
         }
@@ -1609,7 +1609,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
                 false,
                 null);
 
-        Trigger trigger = this.defaultApi.patchTrigger(triggerID, form, predicate);
+        Trigger trigger = this.defaultApi.patchCommandTrigger(triggerID, form, predicate);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(false, trigger.disabled());
@@ -1683,7 +1683,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
                 false,
                 null);
 
-        Trigger trigger = this.defaultApi.patchTrigger(triggerID, form, predicate);
+        Trigger trigger = this.defaultApi.patchCommandTrigger(triggerID, form, predicate);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(false, trigger.disabled());
@@ -1760,7 +1760,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
                 false,
                 null);
 
-        Trigger trigger = this.defaultApi.patchTrigger(triggerID, form, predicate);
+        Trigger trigger = this.defaultApi.patchCommandTrigger(triggerID, form, predicate);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(false, trigger.disabled());
@@ -1830,7 +1830,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
                 false,
                 null);
 
-        Trigger trigger = this.defaultApi.patchTrigger(triggerID, form, null);
+        Trigger trigger = this.defaultApi.patchCommandTrigger(triggerID, form, null);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(false, trigger.disabled());
@@ -1887,7 +1887,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
                 false,
                 null);
 
-        Trigger trigger = this.defaultApi.patchTrigger(triggerID, (TriggeredCommandForm) null, predicate);
+        Trigger trigger = this.defaultApi.patchCommandTrigger(triggerID, null, predicate);
         // verify the result
         Assert.assertEquals(triggerID, trigger.getTriggerID());
         Assert.assertEquals(false, trigger.disabled());
@@ -1938,7 +1938,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
         this.addEmptyMockResponse(403);
 
         try {
-            this.defaultApi.patchTrigger("trigger-1234", form, predicate);
+            this.defaultApi.patchCommandTrigger("trigger-1234", form, predicate);
             Assert.fail("ThingIFRestException should be thrown");
         } catch (ForbiddenException e) {
         }
@@ -1973,7 +1973,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
         this.addEmptyMockResponse(404);
 
         try {
-            this.defaultApi.patchTrigger("trigger-1234", form, predicate);
+            this.defaultApi.patchCommandTrigger("trigger-1234", form, predicate);
             Assert.fail("ThingIFRestException should be thrown");
         } catch (NotFoundException e) {
         }
@@ -2008,7 +2008,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
         this.addEmptyMockResponse(503);
 
         try {
-            this.defaultApi.patchTrigger("trigger-1234", form, predicate);
+            this.defaultApi.patchCommandTrigger("trigger-1234", form, predicate);
             Assert.fail("ThingIFRestException should be thrown");
         } catch (ServiceUnavailableException e) {
         }
@@ -2034,19 +2034,19 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
     // call patchTrigger(String, TriggeredCommandForm, Predicate)
     public void patchCommandTriggerWithNullTargetTest2() throws Exception {
         ThingIFAPI api = this.createDefaultThingIFAPI(this.context, APP_ID, APP_KEY);
-        api.patchTrigger("trigger-1234", getDefaultForm(), getDefaultPredicate());
+        api.patchCommandTrigger("trigger-1234", getDefaultForm(), getDefaultPredicate());
     }
 
     @Test(expected = IllegalArgumentException.class)
     // call patchTrigger(String, null, null)
     public void patchCommandTrigger_NullForm_NullPredicate_Test() throws Exception{
-        this.defaultApi.patchTrigger("trigger-1234", (TriggeredCommandForm)null, null);
+        this.defaultApi.patchCommandTrigger("trigger-1234", null, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
     // call patchTrigger(null, TriggeredCommandForm, Predicate)
     public void patchCommandTrigger_NullTriggerID_Form_Predicate_Test() throws Exception{
-        this.defaultApi.patchTrigger(
+        this.defaultApi.patchCommandTrigger(
                 null,
                 getDefaultForm(),
                 getDefaultPredicate());
@@ -2055,7 +2055,7 @@ public class PatchTriggerTest extends ThingIFAPITestBase {
     @Test(expected = IllegalArgumentException.class)
     // call patchTrigger("", TriggeredCommandForm, Predicate)
     public void patchCommandTrigger_EmptyTriggerID_Form_Predicate_Test() throws Exception{
-        this.defaultApi.patchTrigger(
+        this.defaultApi.patchCommandTrigger(
                 "",
                 getDefaultForm(),
                 getDefaultPredicate());


### PR DESCRIPTION
- Renamed API:
   - ThingIFAPI#patchTrigger(String, ServerCode, Predicate) -> ThingIFAPI#patchServerCodeTrigger(String, ServerCode, Predicate)
   - ThingIFAPI#patchTrigger(String, ServerCode, Predicate, TriggerOptions) -> ThingIFAPI#patchServerCodeTrigger(String, ServerCode, Predicate, TriggerOptions)
   - ThingIFAPI#patchTrigger(String, TriggeredCommandForm, Predicate, TriggerOptions) -> ThingIFAPI#patchCommandTrigger(String, TriggeredCommandForm, Predicate, TriggerOptions)

- Add ThingIFAPI#postNewTrigger(TriggeredCommandForm, Predicate)
- Add ThingIFAPI#patchCommandTrigger(String, TriggeredCommandForm, Predicate)
- Fix API doc
- Add small tests for new methods

The reason to rename APIs is that, when patch trigger with null serverCode or null form,  need to call by this way: 

```
// for servercode
api.patchTrigger("trigger id", (ServerCode)null,  predicate);
// for command
api.patchTrigger("trigger id", (TriggeredCommandForm)null, preidcate)
```
