### PR TITLE
Adjust design to add AllClause

### DIFF
--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -2018,9 +2018,8 @@ public class ThingIFAPI implements Parcelable {
     }
 
     /**
-     * Query history states with trait alias.
+     * Query history states.
      * @param query Instance of {@link HistoryStatesQuery}.
-     *              If clause of query is null, query all history states.
      * @param <S> Type of subclass of {@link TargetState}.
      * @return Pair instance. First element is list of target state.
      *  Second element is next pagination key.

--- a/thingif/src/main/java/com/kii/thingif/clause/query/AllClause.java
+++ b/thingif/src/main/java/com/kii/thingif/clause/query/AllClause.java
@@ -1,0 +1,4 @@
+package com.kii.thingif.clause.query;
+
+public class AllClause implements QueryClause {
+}

--- a/thingif/src/main/java/com/kii/thingif/query/HistoryStatesQuery.java
+++ b/thingif/src/main/java/com/kii/thingif/query/HistoryStatesQuery.java
@@ -5,10 +5,10 @@ import android.support.annotation.Nullable;
 
 import com.kii.thingif.clause.query.QueryClause;
 
-public class HistoryStatesQuery{
+public class HistoryStatesQuery {
 
     private @NonNull String alias;
-    private @Nullable QueryClause clause;
+    private @NonNull QueryClause clause;
     private @Nullable String firmwareVersion;
     private @Nullable Integer bestEffortLimit;
     private @Nullable String nextPaginationKey;
@@ -17,7 +17,7 @@ public class HistoryStatesQuery{
 
     private HistoryStatesQuery(
             @NonNull  String alias,
-            @Nullable QueryClause clause,
+            @NonNull QueryClause clause,
             @Nullable String firmwareVersion,
             @Nullable Integer bestEffortLimit,
             @Nullable String nextPaginationKey) {


### PR DESCRIPTION
To support query all the history state, add AllClause for the purpose. 
In the previous design, when clause in HistoryStateQuery instance is null, then means all query is requested by developer. We found it is not good, and decide to add AllClause. 

Changes: 
- New AllClause
- clause attribute in HistoryStateQuery instance is required. 

Out of scope of this PR:
- Implementation
- Test