### PR TITLE
fix aggregate response parse miss.

### DIFF
--- a/thingif/src/main/java/com/kii/thingif/query/AggregatedResultAdapter.java
+++ b/thingif/src/main/java/com/kii/thingif/query/AggregatedResultAdapter.java
@@ -60,14 +60,11 @@ public class AggregatedResultAdapter<T extends Number, S extends TargetState>
         if (aggregation.has("value")) {
             value = gson.fromJson(aggregation.getAsJsonPrimitive("value"), this.fieldClass);
         }
-        if (aggregation.has("objects")) {
+        if (aggregation.has("object")) {
             aggregateObjects = new ArrayList<>();
-            JsonArray objects = aggregation.getAsJsonArray("objects");
             Type historyStateType = new TypeToken<HistoryState<S>>(){}.getType();
-            for (int i = 0; i < objects.size(); ++i) {
-                HistoryState<S> historyState = gson.fromJson(objects.get(i), historyStateType);
-                aggregateObjects.add(historyState);
-            }
+            HistoryState<S> historyState = gson.fromJson(aggregation.getAsJsonObject("object"), historyStateType);
+            aggregateObjects.add(historyState);
         }
         return new AggregatedResult<T, S>(range, value, aggregateObjects);
     }

--- a/thingif/src/test/java/com/kii/thingif/query/AggregatedResultAdapterTest.java
+++ b/thingif/src/test/java/com/kii/thingif/query/AggregatedResultAdapterTest.java
@@ -34,13 +34,12 @@ public class AggregatedResultAdapterTest {
                     "}," +
                     "\"aggregations\":[{" +
                         "\"value\": " + expect.getValue() + "," +
-                        "\"objects\":[" +
-                            "{" +
-                                "\"_created\": " + historyState.getCreatedAt().getTime() + "," +
-                                "\"power\": " + airState.power + "," +
-                                "\"currentTemperature\": " + airState.currentTemperature +
-                            "}" +
-                        "]" +
+                        "\"name\" : \"max\"," +
+                        "\"object\":{" +
+                            "\"_created\": " + historyState.getCreatedAt().getTime() + "," +
+                            "\"power\": " + airState.power + "," +
+                            "\"currentTemperature\": " + airState.currentTemperature +
+                        "}" +
                     "}]" +
                 "}").toString();
 

--- a/thingif/src/test/java/com/kii/thingif/thingifapi/AggregateTest.java
+++ b/thingif/src/test/java/com/kii/thingif/thingifapi/AggregateTest.java
@@ -73,7 +73,7 @@ public class AggregateTest extends ThingIFAPITestBase {
                 .newBuilder(ALIAS1, range)
                 .setClause(clause)
                 .build();
-        Aggregation aggregation = Aggregation.newMaxAggregation("100", Aggregation.FieldType.INTEGER);
+        Aggregation aggregation = Aggregation.newMaxAggregation("currentTemperature", Aggregation.FieldType.INTEGER);
 
         JSONObject requestBody = JsonUtils.newJson(
                 "{" +
@@ -113,14 +113,13 @@ public class AggregateTest extends ThingIFAPITestBase {
                             "\"to\":" + range.getTo().getTime() +
                         "}," +
                         "\"aggregations\":[{" +
-                            "\"value\": 2000," +
-                            "\"objects\":[" +
-                                "{" +
-                                    "\"_created\": 50," +
-                                    "\"power\": true," +
-                                    "\"currentTemperature\": 25" +
-                                "}" +
-                            "]" +
+                            "\"value\": 25," +
+                            "\"name\": \"max\"," +
+                            "\"object\":{" +
+                                "\"_created\": 50," +
+                                "\"power\": true," +
+                                "\"currentTemperature\": 25" +
+                            "}" +
                         "}]" +
                     "}" +
                 "]" +
@@ -141,7 +140,7 @@ public class AggregateTest extends ThingIFAPITestBase {
         Assert.assertEquals(1, results.size());
         AggregatedResult result = results.get(0);
         Assert.assertEquals(range, result.getTimeRange());
-        Assert.assertEquals(2000, result.getValue().intValue());
+        Assert.assertEquals(25, result.getValue().intValue());
         List<HistoryState<AirConditionerState>> objects = result.getAggregatedObjects();
         Assert.assertNotNull(objects);
         Assert.assertEquals(1, objects.size());
@@ -177,7 +176,7 @@ public class AggregateTest extends ThingIFAPITestBase {
         GroupedHistoryStatesQuery query = GroupedHistoryStatesQuery.Builder
                 .newBuilder(ALIAS1, range)
                 .build();
-        Aggregation aggregation = Aggregation.newMaxAggregation("100", Aggregation.FieldType.INTEGER);
+        Aggregation aggregation = Aggregation.newMaxAggregation("currentTemperature", Aggregation.FieldType.INTEGER);
 
         JSONObject requestBody = JsonUtils.newJson(
                 "{" +
@@ -208,14 +207,13 @@ public class AggregateTest extends ThingIFAPITestBase {
                                 "\"to\":" + range.getTo().getTime() +
                             "}," +
                             "\"aggregations\":[{" +
-                                "\"value\": 2000," +
-                                "\"objects\":[" +
-                                    "{" +
-                                        "\"_created\": 50," +
-                                        "\"power\": true," +
-                                        "\"currentTemperature\": 25" +
-                                    "}" +
-                                "]" +
+                                "\"value\": 25," +
+                                "\"name\" : \"max\"," +
+                                "\"object\":{" +
+                                    "\"_created\": 50," +
+                                    "\"power\": true," +
+                                    "\"currentTemperature\": 25" +
+                                "}" +
                             "}]" +
                         "}" +
                     "]" +
@@ -236,7 +234,7 @@ public class AggregateTest extends ThingIFAPITestBase {
         Assert.assertEquals(1, results.size());
         AggregatedResult result = results.get(0);
         Assert.assertEquals(range, result.getTimeRange());
-        Assert.assertEquals(2000, result.getValue().intValue());
+        Assert.assertEquals(25, result.getValue().intValue());
         List<HistoryState<AirConditionerState>> objects = result.getAggregatedObjects();
         Assert.assertNotNull(objects);
         Assert.assertEquals(1, objects.size());

--- a/thingiftest/src/androidTest/java/com/kii/thingif/largetests/AggregateTest.java
+++ b/thingiftest/src/androidTest/java/com/kii/thingif/largetests/AggregateTest.java
@@ -10,6 +10,7 @@ import com.kii.thingif.clause.query.AllClause;
 import com.kii.thingif.query.AggregatedResult;
 import com.kii.thingif.query.Aggregation;
 import com.kii.thingif.query.GroupedHistoryStatesQuery;
+import com.kii.thingif.query.HistoryState;
 import com.kii.thingif.query.TimeRange;
 import com.kii.thingif.states.AirConditionerState;
 
@@ -132,7 +133,12 @@ public class AggregateTest extends LargeTestCaseBase {
         Assert.assertTrue(range.getFrom().getTime() >= responseRange.getFrom().getTime());
         Assert.assertTrue(range.getTo().getTime() <= responseRange.getTo().getTime());
         Assert.assertEquals(26, result.getValue());
-        Assert.assertNull(result.getAggregatedObjects());
+        Assert.assertNotNull(result.getAggregatedObjects());
+        List<HistoryState<AirConditionerState>> objects = result.getAggregatedObjects();
+        Assert.assertEquals(1, objects.size());
+        HistoryState<AirConditionerState> history = objects.get(0);
+        Assert.assertNotNull(history);
+        Assert.assertEquals(airStates[1], history.getState());
     }
     @Test
     public void successMinTest() throws Exception {
@@ -168,7 +174,12 @@ public class AggregateTest extends LargeTestCaseBase {
         Assert.assertTrue(range.getFrom().getTime() >= responseRange.getFrom().getTime());
         Assert.assertTrue(range.getTo().getTime() <= responseRange.getTo().getTime());
         Assert.assertEquals(23, result.getValue());
-        Assert.assertNull(result.getAggregatedObjects());
+        Assert.assertNotNull(result.getAggregatedObjects());
+        List<HistoryState<AirConditionerState>> objects = result.getAggregatedObjects();
+        Assert.assertEquals(1, objects.size());
+        HistoryState<AirConditionerState> history = objects.get(0);
+        Assert.assertNotNull(history);
+        Assert.assertEquals(airStates[0], history.getState());
     }
     @Test
     public void successMeanTest() throws Exception {


### PR DESCRIPTION
ThingIFAPI#aggregateのレスポンス処理に間違いがあったので修正しました。レビューをお願いします。

MINとMAXの場合aggregations.objectに対象となるHistoryStateが入っていましたが、
aggregations.objectsでパースシテたので解釈できていませんでした。