### PR TITLE
change AliasAction and APIs.

### DIFF
--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -115,7 +115,7 @@ public class ThingIFAPI {
                 @Nullable Context context,
                 @NonNull KiiApp app,
                 @NonNull Owner owner,
-                @NonNull Map<String, Class<? extends Action>> actionTypes,
+                @NonNull Map<String, List<Class<? extends Action>>> actionTypes,
                 @NonNull Map<String, Class<? extends TargetState>> stateTypes
         ) {
             this.context = context;
@@ -129,7 +129,7 @@ public class ThingIFAPI {
          * @param context Application context.
          * @param app Kii Cloud Application.
          * @param owner Specify who uses the ThingIFAPI.
-         * @param actionTypes Map of alias and action class.
+         * @param actionTypes Map of alias and action classes.
          * @param stateTypes Map of alias and target state class.
          * @return Builder instance.
          */
@@ -138,7 +138,7 @@ public class ThingIFAPI {
                 @NonNull Context context,
                 @NonNull KiiApp app,
                 @NonNull Owner owner,
-                @NonNull Map<String, Class<? extends Action>> actionTypes,
+                @NonNull Map<String, List<Class<? extends Action>>> actionTypes,
                 @NonNull Map<String, Class<? extends TargetState>> stateTypes) {
             if (context == null) {
                 throw new IllegalArgumentException("context is null");
@@ -176,7 +176,7 @@ public class ThingIFAPI {
                     context,
                     app,
                     owner,
-                    new HashMap<String, Class<? extends Action>>(),
+                    new HashMap<String, List<Class<? extends Action>>>(),
                     new HashMap<String, Class<? extends TargetState>>());
         }
 
@@ -186,13 +186,15 @@ public class ThingIFAPI {
          *
          * @param app Kii Cloud Application.
          * @param owner Specify who uses the ThingIFAPI.
+         * @param actionTypes Map of alias and action classes.
+         * @param stateTypes Map of alias and target state class.
          * @return Builder instance.
          */
         @NonNull
         public static Builder _newBuilder(
                 @NonNull KiiApp app,
                 @NonNull Owner owner,
-                @NonNull Map<String, Class<? extends Action>> actionTypes,
+                @NonNull Map<String, List<Class<? extends Action>>> actionTypes,
                 @NonNull Map<String, Class<? extends TargetState>> stateTypes) {
             if (app == null) {
                 throw new IllegalArgumentException("app is null");
@@ -271,7 +273,7 @@ public class ThingIFAPI {
         @NonNull
         public Builder registerActions(
                 @NonNull String alias,
-                @NonNull Class<? extends Action> actionClass){
+                @NonNull List<Class<? extends Action>> actionClass){
             this.actionTypes.put(alias, actionClass);
             return this;
         }

--- a/thingif/src/main/java/com/kii/thingif/command/Action.java
+++ b/thingif/src/main/java/com/kii/thingif/command/Action.java
@@ -15,6 +15,7 @@ import java.util.Map;
  * Marks a class as single action of command. The class must implement this interface and
  * define single action as field.
  * A single action is composed from action name + action payload.
+ * Action name is property name in class implement Action.
  * Action payload can be any of Object, Array String, Boolean, Number.
  * <br>
  * SDK serializes Action objects using

--- a/thingif/src/main/java/com/kii/thingif/command/Action.java
+++ b/thingif/src/main/java/com/kii/thingif/command/Action.java
@@ -13,7 +13,9 @@ import java.util.Map;
 
 /**
  * Marks a class as single action of command. The class must implement this interface and
- * define single action as fields.
+ * define single action as field.
+ * A single action is composed from action name + action payload.
+ * Action payload can be any of Object, Array String, Boolean, Number.
  * <br>
  * SDK serializes Action objects using
  * <a href="https://github.com/google/gson/blob/master/UserGuide.md#TOC-Object-Examples">Gson </a>,

--- a/thingif/src/main/java/com/kii/thingif/command/Action.java
+++ b/thingif/src/main/java/com/kii/thingif/command/Action.java
@@ -8,11 +8,12 @@ import com.kii.thingif.trigger.Predicate;
 import com.kii.thingif.trigger.TriggerOptions;
 import com.kii.thingif.trigger.TriggeredCommandForm;
 
+import java.util.List;
 import java.util.Map;
 
 /**
- * Marks a class as group of single actions of command. The class must implement this interface and
- * define single actions as fields.
+ * Marks a class as single action of command. The class must implement this interface and
+ * define single action as fields.
  * <br>
  * SDK serializes Action objects using
  * <a href="https://github.com/google/gson/blob/master/UserGuide.md#TOC-Object-Examples">Gson </a>,
@@ -27,7 +28,7 @@ import java.util.Map;
  * class of Action to ThingIFAPI instance when constructed by the following 2 APIs:
  * <ul>
  * <li>{@link com.kii.thingif.ThingIFAPI.Builder#newBuilder(Context, KiiApp, Owner, Map, Map)}
- * <li>{@link com.kii.thingif.ThingIFAPI.Builder#registerActions(String, Class)}.
+ * <li>{@link com.kii.thingif.ThingIFAPI.Builder#registerActions(String, List<Class>)}.
  * </ul>
  *
  */

--- a/thingif/src/main/java/com/kii/thingif/command/AliasAction.java
+++ b/thingif/src/main/java/com/kii/thingif/command/AliasAction.java
@@ -7,33 +7,36 @@ import android.text.TextUtils;
 
 import com.google.gson.Gson;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * Represent Action of alias
- * @param <T> Action class
  */
-public class AliasAction<T extends Action> implements Parcelable{
+public class AliasAction implements Parcelable{
     @NonNull private String alias;
-    @NonNull private T action;
+    @NonNull private List<? extends Action> actions;
 
     private transient volatile int hashCode; // cached hashcode for performance
 
     /**
      * Initialize AliasAction instance.
      * @param alias alias name.
-     * @param action instance of concrete Action class.
+     * @param actions list of concrete Action instance.
      */
     public AliasAction(
             @NonNull String alias,
-            @NonNull T action) {
+            @NonNull List<? extends Action> actions) {
         if (TextUtils.isEmpty(alias)) {
             throw new IllegalArgumentException("alias is empty or null");
         }
 
-        if (action == null) {
-            throw new IllegalArgumentException("action is null");
+        if (actions == null) {
+            throw new IllegalArgumentException("actions is null");
         }
         this.alias = alias;
-        this.action = action;
+        this.actions = actions;
     }
 
     @NonNull
@@ -42,8 +45,8 @@ public class AliasAction<T extends Action> implements Parcelable{
     }
 
     @NonNull
-    public T getAction() {
-        return action;
+    public List<? extends Action> getActions() {
+        return actions;
     }
 
     @Override
@@ -81,10 +84,9 @@ public class AliasAction<T extends Action> implements Parcelable{
     public boolean equals(Object o) {
         if (o == null) return false;
         if (!(o instanceof AliasAction)) return false;
-        if (!((AliasAction) o).getAction().getClass().equals(this.action.getClass())) return false;
-        T action = (T)((AliasAction) o).getAction();
-        return this.action.equals(action) &&
-                this.alias.equals(((AliasAction) o).getAlias());
+        AliasAction other = (AliasAction)o;
+        return Arrays.equals(this.actions.toArray(), other.actions.toArray()) &&
+                this.alias.equals(other.getAlias());
     }
 
     @Override
@@ -93,7 +95,7 @@ public class AliasAction<T extends Action> implements Parcelable{
         if (result == 0) {
             result = 17;
             result = 31 * result + this.alias.hashCode();
-            result = 31 * result + this.action.hashCode();
+            result = 31 * result + this.actions.hashCode();
             this.hashCode = result;
         }
         return result;

--- a/thingif/src/main/java/com/kii/thingif/command/AliasAction.java
+++ b/thingif/src/main/java/com/kii/thingif/command/AliasAction.java
@@ -23,7 +23,7 @@ public class AliasAction implements Parcelable{
     /**
      * Initialize AliasAction instance.
      * @param alias alias name.
-     * @param actions list of concrete Action instance.
+     * @param actions list of concrete Action instances.
      */
     public AliasAction(
             @NonNull String alias,

--- a/thingif/src/main/java/com/kii/thingif/command/AliasAction.java
+++ b/thingif/src/main/java/com/kii/thingif/command/AliasAction.java
@@ -16,7 +16,7 @@ import java.util.List;
  */
 public class AliasAction implements Parcelable{
     @NonNull private String alias;
-    @NonNull private List<? extends Action> actions;
+    @NonNull private List<Action> actions;
 
     private transient volatile int hashCode; // cached hashcode for performance
 
@@ -27,7 +27,7 @@ public class AliasAction implements Parcelable{
      */
     public AliasAction(
             @NonNull String alias,
-            @NonNull List<? extends Action> actions) {
+            @NonNull List<Action> actions) {
         if (TextUtils.isEmpty(alias)) {
             throw new IllegalArgumentException("alias is empty or null");
         }
@@ -45,7 +45,7 @@ public class AliasAction implements Parcelable{
     }
 
     @NonNull
-    public List<? extends Action> getActions() {
+    public List<Action> getActions() {
         return actions;
     }
 

--- a/thingif/src/main/java/com/kii/thingif/command/Command.java
+++ b/thingif/src/main/java/com/kii/thingif/command/Command.java
@@ -25,7 +25,7 @@ public class Command implements Parcelable {
     @SerializedName("issuer")
     private final @NonNull TypedID issuerID;
     @SerializedName("actions")
-    private final @NonNull List<AliasAction<? extends Action>> aliasActions;
+    private final @NonNull List<AliasAction> aliasActions;
     @SerializedName("actionResults")
     private final @Nullable List<AliasActionResult> aliasActionResults;
     @SerializedName("commandState")
@@ -41,7 +41,7 @@ public class Command implements Parcelable {
 
     Command(
             @NonNull TypedID issuerID,
-            @NonNull List<AliasAction<? extends Action>> aliasActions,
+            @NonNull List<AliasAction> aliasActions,
             @Nullable String commandID,
             @Nullable TypedID targetID,
             @Nullable List<AliasActionResult> aliasActionResults,
@@ -97,26 +97,22 @@ public class Command implements Parcelable {
      * @return action of this command.
      */
     @NonNull
-    public List<AliasAction<? extends Action>> getAliasActions() {
+    public List<AliasAction> getAliasActions() {
         return this.aliasActions;
     }
 
     /**
      * Retrieve specified AliasAction
      * @param alias alias to retrieve
-     * @param clsOfT Class of T.
-     * @param <T> Type of Action
      * @return list of AliasAction with the specified type.
      */
     @NonNull
-    public <T extends Action> List<AliasAction<T>> getAliasAction(
-            @NonNull String alias,
-            @NonNull Class<T> clsOfT) {
-        List<AliasAction<T>> foundActions = new ArrayList<>();
-        for (AliasAction<? extends Action> aliasAction: this.aliasActions) {
-            if (aliasAction.getAlias().equals(alias) &&
-                    aliasAction.getAction().getClass().equals(clsOfT)){
-                foundActions.add((AliasAction<T>) aliasAction);
+    public List<AliasAction> getAliasAction(
+            @NonNull String alias) {
+        List<AliasAction> foundActions = new ArrayList<>();
+        for (AliasAction aliasAction: this.aliasActions) {
+            if (aliasAction.getAlias().equals(alias)){
+                foundActions.add((AliasAction) aliasAction);
             }
         }
         return foundActions;

--- a/thingif/src/main/java/com/kii/thingif/command/CommandForm.java
+++ b/thingif/src/main/java/com/kii/thingif/command/CommandForm.java
@@ -38,7 +38,7 @@ public final class CommandForm {
 
 
     public static class Builder{
-        private @NonNull List<AliasAction<? extends Action>> aliasActions;
+        private @NonNull List<AliasAction> aliasActions;
         private @Nullable String title;
         private @Nullable String description;
         private @Nullable JSONObject metadata;
@@ -54,7 +54,7 @@ public final class CommandForm {
          */
         @NonNull
         public static Builder newBuilder() {
-            List<AliasAction<? extends Action>> actions = new ArrayList<>();
+            List<AliasAction> actions = new ArrayList<>();
             return new Builder(actions);
         }
 
@@ -66,7 +66,7 @@ public final class CommandForm {
          */
         @NonNull
         public static Builder newBuilder(
-                @NonNull List<AliasAction<? extends Action>> aliasActions) {
+                @NonNull List<AliasAction> aliasActions) {
             if (aliasActions == null || aliasActions.size() == 0) {
                 throw new IllegalArgumentException("aliasActions is null or empty");
             }
@@ -81,7 +81,7 @@ public final class CommandForm {
          */
         @NonNull
         public Builder addAliasAction(
-                @NonNull AliasAction<? extends Action> aliasAction) {
+                @NonNull AliasAction aliasAction) {
             if (aliasAction == null) {
                 throw new IllegalArgumentException("aliasAction is null");
             }
@@ -174,7 +174,7 @@ public final class CommandForm {
      * @return aliasActions
      */
     @NonNull
-    public List<AliasAction<? extends Action>> getAliasActions() {
+    public List<AliasAction> getAliasActions() {
         return this.aliasActions;
     }
 

--- a/thingif/src/main/java/com/kii/thingif/internal/gson/AliasActionAdapter.java
+++ b/thingif/src/main/java/com/kii/thingif/internal/gson/AliasActionAdapter.java
@@ -14,15 +14,16 @@ import com.kii.thingif.command.AliasAction;
 import com.kii.thingif.exception.UnregisteredAliasException;
 
 import java.lang.reflect.Type;
+import java.util.List;
 import java.util.Map;
 
 public class AliasActionAdapter implements
         JsonSerializer<AliasAction>,
         JsonDeserializer<AliasAction> {
 
-    private Map<String, Class<? extends Action>> actionTypes;
+    private Map<String, List<Class<? extends Action>>> actionTypes;
 
-    public AliasActionAdapter(Map<String, Class<? extends Action>> actionTypes) {
+    public AliasActionAdapter(Map<String, List<Class<? extends Action>>> actionTypes) {
         this.actionTypes = actionTypes;
     }
     @Override

--- a/thingif/src/main/java/com/kii/thingif/trigger/TriggeredCommandForm.java
+++ b/thingif/src/main/java/com/kii/thingif/trigger/TriggeredCommandForm.java
@@ -66,7 +66,7 @@ public class TriggeredCommandForm {
          */
         @NonNull
         public static Builder newBuilder(
-                @NonNull List<AliasAction<? extends Action>> aliasActions)
+                @NonNull List<AliasAction> aliasActions)
         {
             return new Builder(aliasActions);
         }
@@ -76,7 +76,7 @@ public class TriggeredCommandForm {
          * @return builder instance.
          */
         public static Builder newBuilder() {
-            return new Builder(new ArrayList<AliasAction<? extends Action>>());
+            return new Builder(new ArrayList<AliasAction>());
         }
 
 //        /**
@@ -132,7 +132,7 @@ public class TriggeredCommandForm {
          * @return aliasActions
          */
         @NonNull
-        public List<AliasAction<? extends Action>> getAliasActions() {
+        public List<AliasAction> getAliasActions() {
             return this.aliasActions;
         }
 
@@ -322,7 +322,7 @@ public class TriggeredCommandForm {
      * @return aliasActions
      */
     @NonNull
-    public List<AliasAction<? extends Action>> getAliasActions() {
+    public List<AliasAction> getAliasActions() {
         return this.aliasActions;
     }
 


### PR DESCRIPTION
このPRはAliasActionに複数のActionを持たせるための修正を行うベースPRです。

ここではAPIの変更のみを行いますが、一部Genericsパラメータを除くために実装の修正もしています。

同一のActionに複数のフィールドが存在する可能性があるため(例: RGBの変更にてsetR: setG: setB:が1つのActionになる等)、actionTypesは内部的にMap<(エイリアス名), Map<フィールド名, アクションクラス>>となる予定です。、