### PR TITLE
redesign action(new)

### DIFF
--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -98,6 +98,9 @@ public class ThingIFAPI {
 
     private Gson gson;
 
+    private static String actionsMapKey(String alias, String actionName) {
+        return alias+":"+actionName;
+    }
     public static class Builder {
 
         private static final String TAG = Builder.class.getSimpleName();
@@ -129,33 +132,6 @@ public class ThingIFAPI {
          * @param context Application context.
          * @param app Kii Cloud Application.
          * @param owner Specify who uses the ThingIFAPI.
-         * @param actionTypes Map of alias and action class.
-         * @param stateTypes Map of alias and target state class.
-         * @return Builder instance.
-         */
-        @NonNull
-        public static Builder newBuilder(
-                @NonNull Context context,
-                @NonNull KiiApp app,
-                @NonNull Owner owner,
-                @NonNull Map<String, Class<? extends Action>> actionTypes,
-                @NonNull Map<String, Class<? extends TargetState>> stateTypes) {
-            if (context == null) {
-                throw new IllegalArgumentException("context is null");
-            }
-            if (app == null) {
-                throw new IllegalArgumentException("app is null");
-            }
-            if (owner == null) {
-                throw new IllegalArgumentException("owner is null");
-            }
-            return new Builder(context, app, owner, actionTypes, stateTypes);
-        }
-
-        /** Instantiate new Builder.
-         * @param context Application context.
-         * @param app Kii Cloud Application.
-         * @param owner Specify who uses the ThingIFAPI.
          * @return Builder instance.
          */
         @NonNull
@@ -178,29 +154,6 @@ public class ThingIFAPI {
                     owner,
                     new HashMap<String, Class<? extends Action>>(),
                     new HashMap<String, Class<? extends TargetState>>());
-        }
-
-        /**
-         * Instantiate new Builder without Context.
-         * This method is for internal use only. Do not call it from your application.
-         *
-         * @param app Kii Cloud Application.
-         * @param owner Specify who uses the ThingIFAPI.
-         * @return Builder instance.
-         */
-        @NonNull
-        public static Builder _newBuilder(
-                @NonNull KiiApp app,
-                @NonNull Owner owner,
-                @NonNull Map<String, Class<? extends Action>> actionTypes,
-                @NonNull Map<String, Class<? extends TargetState>> stateTypes) {
-            if (app == null) {
-                throw new IllegalArgumentException("app is null");
-            }
-            if (owner == null) {
-                throw new IllegalArgumentException("owner is null");
-            }
-            return new Builder(null, app, owner, actionTypes, stateTypes);
         }
 
         /**
@@ -269,10 +222,11 @@ public class ThingIFAPI {
          * @return builder instance for chaining call.
          */
         @NonNull
-        public Builder registerActions(
+        public Builder registerAction(
                 @NonNull String alias,
+                @NonNull String actionName,
                 @NonNull Class<? extends Action> actionClass){
-            this.actionTypes.put(alias, actionClass);
+            this.actionTypes.put(ThingIFAPI.actionsMapKey(alias, actionName), actionClass);
             return this;
         }
 

--- a/thingif/src/main/java/com/kii/thingif/command/Action.java
+++ b/thingif/src/main/java/com/kii/thingif/command/Action.java
@@ -11,8 +11,7 @@ import com.kii.thingif.trigger.TriggeredCommandForm;
 import java.util.Map;
 
 /**
- * Marks a class as group of single actions of command. The class must implement this interface and
- * define single actions as fields.
+ * Marks a class as a single action.
  * <br>
  * SDK serializes Action objects using
  * <a href="https://github.com/google/gson/blob/master/UserGuide.md#TOC-Object-Examples">Gson </a>,
@@ -21,15 +20,14 @@ import java.util.Map;
  * <li>{@link com.kii.thingif.ThingIFAPI#postNewCommand(CommandForm)}
  * <li>{@link com.kii.thingif.ThingIFAPI#postNewTrigger(TriggeredCommandForm, Predicate, TriggerOptions)}
  * </ul>
- * Null value of field is not included in serialized json.
  * <br><br>
  * When parsing json formatted action from kii cloud server, SDK uses Gson too. You must register
- * class of Action to ThingIFAPI instance when constructed by the following 2 APIs:
+ * class of Action to ThingIFAPI instance when constructed API:
  * <ul>
- * <li>{@link com.kii.thingif.ThingIFAPI.Builder#newBuilder(Context, KiiApp, Owner, Map, Map)}
- * <li>{@link com.kii.thingif.ThingIFAPI.Builder#registerActions(String, Class)}.
+ * <li>{@link com.kii.thingif.ThingIFAPI.Builder#registerAction(String, String, Class)} (String, Class)}.
  * </ul>
  *
  */
 public interface Action {
+    String getActionName();
 }

--- a/thingif/src/main/java/com/kii/thingif/command/AliasAction.java
+++ b/thingif/src/main/java/com/kii/thingif/command/AliasAction.java
@@ -7,6 +7,7 @@ import android.text.TextUtils;
 
 import com.google.gson.Gson;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -103,5 +104,17 @@ public class AliasAction implements Parcelable{
             this.hashCode = result;
         }
         return result;
+    }
+
+    /**
+     * Retrieve actions by Class of Action
+     * @param classOfT class of Action
+     * @param <T> Action Type
+     * @return list of Action instance.
+     */
+    @NonNull
+    public <T extends Action> List<T> getActions(Class<T> classOfT) {
+        //TODO: // FIXME: 2017/03/27
+        return new ArrayList<>();
     }
 }

--- a/thingif/src/main/java/com/kii/thingif/command/AliasAction.java
+++ b/thingif/src/main/java/com/kii/thingif/command/AliasAction.java
@@ -32,7 +32,7 @@ public class AliasAction implements Parcelable{
         }
 
         if (actions == null) {
-            throw new IllegalArgumentException("action is null");
+            throw new IllegalArgumentException("actions is null");
         }
         this.alias = alias;
         this.actions = new ArrayList<>();
@@ -119,15 +119,5 @@ public class AliasAction implements Parcelable{
     public <T extends Action> List<T> getActions(Class<T> classOfT) {
         //TODO: // FIXME: 2017/03/27
         return new ArrayList<>();
-    }
-
-    /**
-     * Add action to actions list.
-     * @param action action to add.
-     * @return this instance.
-     */
-    public AliasAction addAction(Action action) {
-        this.actions.add(action);
-        return this;
     }
 }

--- a/thingif/src/main/java/com/kii/thingif/command/AliasAction.java
+++ b/thingif/src/main/java/com/kii/thingif/command/AliasAction.java
@@ -11,11 +11,10 @@ import java.util.List;
 
 /**
  * Represent Action of alias
- * @param <T> Action class
  */
-public class AliasAction<T extends Action> implements Parcelable{
+public class AliasAction implements Parcelable{
     @NonNull private String alias;
-    @NonNull private List<T> actions;
+    @NonNull private List<? extends Action> actions;
 
     private transient volatile int hashCode; // cached hashcode for performance
 
@@ -26,7 +25,7 @@ public class AliasAction<T extends Action> implements Parcelable{
      */
     public AliasAction(
             @NonNull String alias,
-            @NonNull List<T> actions) {
+            @NonNull List<? extends Action> actions) {
         if (TextUtils.isEmpty(alias)) {
             throw new IllegalArgumentException("alias is empty or null");
         }
@@ -44,7 +43,7 @@ public class AliasAction<T extends Action> implements Parcelable{
     }
 
     @NonNull
-    public List<T> getActions() {
+    public List<? extends Action> getActions() {
         return actions;
     }
 

--- a/thingif/src/main/java/com/kii/thingif/command/AliasAction.java
+++ b/thingif/src/main/java/com/kii/thingif/command/AliasAction.java
@@ -44,7 +44,7 @@ public class AliasAction<T extends Action> implements Parcelable{
     }
 
     @NonNull
-    public List<T> getAction() {
+    public List<T> getActions() {
         return actions;
     }
 

--- a/thingif/src/main/java/com/kii/thingif/command/AliasAction.java
+++ b/thingif/src/main/java/com/kii/thingif/command/AliasAction.java
@@ -7,33 +7,35 @@ import android.text.TextUtils;
 
 import com.google.gson.Gson;
 
+import java.util.List;
+
 /**
  * Represent Action of alias
  * @param <T> Action class
  */
 public class AliasAction<T extends Action> implements Parcelable{
     @NonNull private String alias;
-    @NonNull private T action;
+    @NonNull private List<T> actions;
 
     private transient volatile int hashCode; // cached hashcode for performance
 
     /**
      * Initialize AliasAction instance.
      * @param alias alias name.
-     * @param action instance of concrete Action class.
+     * @param actions instance of concrete Action class.
      */
     public AliasAction(
             @NonNull String alias,
-            @NonNull T action) {
+            @NonNull List<T> actions) {
         if (TextUtils.isEmpty(alias)) {
             throw new IllegalArgumentException("alias is empty or null");
         }
 
-        if (action == null) {
+        if (actions == null) {
             throw new IllegalArgumentException("action is null");
         }
         this.alias = alias;
-        this.action = action;
+        this.actions = actions;
     }
 
     @NonNull
@@ -42,8 +44,8 @@ public class AliasAction<T extends Action> implements Parcelable{
     }
 
     @NonNull
-    public T getAction() {
-        return action;
+    public List<T> getAction() {
+        return actions;
     }
 
     @Override
@@ -54,15 +56,17 @@ public class AliasAction<T extends Action> implements Parcelable{
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeString(this.alias);
-        dest.writeSerializable(this.action.getClass());
-        dest.writeString(new Gson().toJson(this.action));
+        //TODO: // FIXME: 2017/03/27
+//        dest.writeSerializable(this.action.getClass());
+//        dest.writeString(new Gson().toJson(this.action));
     }
 
     public AliasAction(Parcel in) {
         this.alias = in.readString();
-        Class<T> actionType = (Class<T>)in.readSerializable();
-        String jsonString = in.readString();
-        this.action = new Gson().fromJson(jsonString, actionType);
+        //TODO: // FIXME: 2017/03/27
+//        Class<T> actionType = (Class<T>)in.readSerializable();
+//        String jsonString = in.readString();
+//        this.action = new Gson().fromJson(jsonString, actionType);
     }
 
     public static final Creator<AliasAction> CREATOR = new Creator<AliasAction>() {
@@ -79,12 +83,14 @@ public class AliasAction<T extends Action> implements Parcelable{
 
     @Override
     public boolean equals(Object o) {
-        if (o == null) return false;
-        if (!(o instanceof AliasAction)) return false;
-        if (!((AliasAction) o).getAction().getClass().equals(this.action.getClass())) return false;
-        T action = (T)((AliasAction) o).getAction();
-        return this.action.equals(action) &&
-                this.alias.equals(((AliasAction) o).getAlias());
+        return false;
+        //TODO: // FIXME: 2017/03/27
+//        if (o == null) return false;
+//        if (!(o instanceof AliasAction)) return false;
+//        if (!((AliasAction) o).getAction().getClass().equals(this.action.getClass())) return false;
+//        T action = (T)((AliasAction) o).getAction();
+//        return this.action.equals(action) &&
+//                this.alias.equals(((AliasAction) o).getAlias());
     }
 
     @Override
@@ -93,7 +99,8 @@ public class AliasAction<T extends Action> implements Parcelable{
         if (result == 0) {
             result = 17;
             result = 31 * result + this.alias.hashCode();
-            result = 31 * result + this.action.hashCode();
+            //TODO // FIXME: 2017/03/27
+//            result = 31 * result + this.action.hashCode();
             this.hashCode = result;
         }
         return result;

--- a/thingif/src/main/java/com/kii/thingif/command/AliasAction.java
+++ b/thingif/src/main/java/com/kii/thingif/command/AliasAction.java
@@ -15,7 +15,7 @@ import java.util.List;
  */
 public class AliasAction implements Parcelable{
     @NonNull private String alias;
-    @NonNull private List<? extends Action> actions;
+    @NonNull private List<Action> actions;
 
     private transient volatile int hashCode; // cached hashcode for performance
 
@@ -35,7 +35,10 @@ public class AliasAction implements Parcelable{
             throw new IllegalArgumentException("action is null");
         }
         this.alias = alias;
-        this.actions = actions;
+        this.actions = new ArrayList<>();
+        for (Action action: actions) {
+            this.actions.add(action);
+        }
     }
 
     @NonNull
@@ -116,5 +119,15 @@ public class AliasAction implements Parcelable{
     public <T extends Action> List<T> getActions(Class<T> classOfT) {
         //TODO: // FIXME: 2017/03/27
         return new ArrayList<>();
+    }
+
+    /**
+     * Add action to actions list.
+     * @param action action to add.
+     * @return this instance.
+     */
+    public AliasAction addAction(Action action) {
+        this.actions.add(action);
+        return this;
     }
 }

--- a/thingif/src/main/java/com/kii/thingif/command/Command.java
+++ b/thingif/src/main/java/com/kii/thingif/command/Command.java
@@ -25,7 +25,7 @@ public class Command implements Parcelable {
     @SerializedName("issuer")
     private final @NonNull TypedID issuerID;
     @SerializedName("actions")
-    private final @NonNull List<AliasAction<? extends Action>> aliasActions;
+    private final @NonNull List<AliasAction> aliasActions;
     @SerializedName("actionResults")
     private final @Nullable List<AliasActionResult> aliasActionResults;
     @SerializedName("commandState")
@@ -41,7 +41,7 @@ public class Command implements Parcelable {
 
     Command(
             @NonNull TypedID issuerID,
-            @NonNull List<AliasAction<? extends Action>> aliasActions,
+            @NonNull List<AliasAction> aliasActions,
             @Nullable String commandID,
             @Nullable TypedID targetID,
             @Nullable List<AliasActionResult> aliasActionResults,
@@ -97,26 +97,22 @@ public class Command implements Parcelable {
      * @return action of this command.
      */
     @NonNull
-    public List<AliasAction<? extends Action>> getAliasActions() {
+    public List<AliasAction> getAliasActions() {
         return this.aliasActions;
     }
 
     /**
      * Retrieve specified AliasAction
      * @param alias alias to retrieve
-     * @param clsOfT Class of T.
-     * @param <T> Type of Action
      * @return list of AliasAction with the specified type.
      */
     @NonNull
-    public <T extends Action> List<AliasAction<T>> getAliasAction(
-            @NonNull String alias,
-            @NonNull Class<T> clsOfT) {
-        List<AliasAction<T>> foundActions = new ArrayList<>();
-        for (AliasAction<? extends Action> aliasAction: this.aliasActions) {
-            if (aliasAction.getAlias().equals(alias) &&
-                    aliasAction.getAction().getClass().equals(clsOfT)){
-                foundActions.add((AliasAction<T>) aliasAction);
+    public List<AliasAction> getAliasAction(
+            @NonNull String alias) {
+        List<AliasAction> foundActions = new ArrayList<>();
+        for (AliasAction aliasAction: this.aliasActions) {
+            if (aliasAction.getAlias().equals(alias)){
+                foundActions.add( aliasAction);
             }
         }
         return foundActions;

--- a/thingif/src/main/java/com/kii/thingif/internal/gson/ActionAdapter.java
+++ b/thingif/src/main/java/com/kii/thingif/internal/gson/ActionAdapter.java
@@ -26,30 +26,31 @@ class ActionAdapter implements
     }
     @Override
     public JsonElement serialize(Action src, Type typeOfSrc, JsonSerializationContext context) {
-        if (src == null) return null;
-        Gson gson = new Gson();
-        JsonObject json = gson.toJsonTree(src).getAsJsonObject();
-        JsonArray ret = new JsonArray();
-        for (Map.Entry<String, JsonElement> element: json.entrySet()) {
-            JsonObject singleAction = new JsonObject();
-            String key = element.getKey();
-            JsonElement value = element.getValue();
-            if (value.isJsonPrimitive()) {
-                JsonPrimitive primVale = (JsonPrimitive)value;
-                if (primVale.isString()) {
-                    singleAction.addProperty(key, primVale.getAsString());
-                }else if (primVale.isBoolean()){
-                    singleAction.addProperty(key, primVale.getAsBoolean());
-                }else if (primVale.isNumber()) {
-                    singleAction.addProperty(key, primVale.getAsNumber());
-                }
-            }else{
-                singleAction.add(key, value);
-            }
-            ret.add(singleAction);
-        }
-        return ret;
-
+//        if (src == null) return null;
+//        Gson gson = new Gson();
+//        JsonObject json = gson.toJsonTree(src).getAsJsonObject();
+//        JsonArray ret = new JsonArray();
+//        for (Map.Entry<String, JsonElement> element: json.entrySet()) {
+//            JsonObject singleAction = new JsonObject();
+//            String key = element.getKey();
+//            JsonElement value = element.getValue();
+//            if (value.isJsonPrimitive()) {
+//                JsonPrimitive primVale = (JsonPrimitive)value;
+//                if (primVale.isString()) {
+//                    singleAction.addProperty(key, primVale.getAsString());
+//                }else if (primVale.isBoolean()){
+//                    singleAction.addProperty(key, primVale.getAsBoolean());
+//                }else if (primVale.isNumber()) {
+//                    singleAction.addProperty(key, primVale.getAsNumber());
+//                }
+//            }else{
+//                singleAction.add(key, value);
+//            }
+//            ret.add(singleAction);
+//        }
+//        return ret;
+        //TODO: // FIXME: 2017/03/27
+        return null;
     }
 
     @Override

--- a/thingif/src/main/java/com/kii/thingif/internal/gson/AliasActionAdapter.java
+++ b/thingif/src/main/java/com/kii/thingif/internal/gson/AliasActionAdapter.java
@@ -43,27 +43,29 @@ public class AliasActionAdapter implements
 
     @Override
     public AliasAction deserialize(JsonElement jsonElement, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-        if (jsonElement == null) return null;
-
-        JsonObject json = jsonElement.getAsJsonObject();
-
-        if (!json.entrySet().iterator().hasNext()){
-            return null;
-        }
-        Map.Entry<String, JsonElement> firstEntry = json.entrySet().iterator().next();
-        String alias = firstEntry.getKey();
-
-        if (!this.actionTypes.containsKey(firstEntry.getKey())) {
-            throw new JsonParseException(new UnregisteredAliasException(alias, true));
-        }
-        Class<? extends Action> actionClass = this.actionTypes.get(alias);
-        JsonElement actionJson = json.get(alias);
-        Gson gson = new GsonBuilder()
-                .registerTypeAdapter(
-                        Action.class,
-                        new ActionAdapter(actionClass))
-                .create();
-        Action action = gson.fromJson(actionJson, Action.class);
-        return new AliasAction(alias, action);
+//        if (jsonElement == null) return null;
+//
+//        JsonObject json = jsonElement.getAsJsonObject();
+//
+//        if (!json.entrySet().iterator().hasNext()){
+//            return null;
+//        }
+//        Map.Entry<String, JsonElement> firstEntry = json.entrySet().iterator().next();
+//        String alias = firstEntry.getKey();
+//
+//        if (!this.actionTypes.containsKey(firstEntry.getKey())) {
+//            throw new JsonParseException(new UnregisteredAliasException(alias, true));
+//        }
+//        Class<? extends Action> actionClass = this.actionTypes.get(alias);
+//        JsonElement actionJson = json.get(alias);
+//        Gson gson = new GsonBuilder()
+//                .registerTypeAdapter(
+//                        Action.class,
+//                        new ActionAdapter(actionClass))
+//                .create();
+//        Action action = gson.fromJson(actionJson, Action.class);
+//        return new AliasAction(alias, action);
+        //TODO: // FIXME: 2017/03/27
+        return null;
     }
 }


### PR DESCRIPTION
According to the spec of command actions, the element of aliasAction can only be single action. That means the following 2 case: 
Case 1: `{"AirConditionerAlias":[{"turnPower": true}, {"setPresetTemperature": 23}]}` is acceptable. 
Case 2: `{"AirConditionerAlias": [{"turnPower": true, "setPresetTemperature": 23}]}` is not allowed. 

The previous design to provide Acton as group of single actions, aimed to accept case 2. As a result, the server doesn't accept case 2, there is not any benefit with previous design. We decide to provide Action as single action. 

#### Brief of new design
- Action presents single action
- AliasAction hold actions List
- Register Action with alias and actionName with Action class

#### Need the following changes:
- Change action registration method of ThingIFAPI.Builder
- Change Action description
- Change action of AliasAction to List
- Change ActionAdapter and AliasActionAdapter

