### PR TITLE
fix failed small tests

### DIFF
--- a/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
+++ b/thingif/src/main/java/com/kii/thingif/ThingIFAPI.java
@@ -13,7 +13,6 @@ import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
-import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
 import com.kii.thingif.clause.query.QueryClause;
 import com.kii.thingif.command.Action;
@@ -30,7 +29,6 @@ import com.kii.thingif.exception.ThingIFException;
 import com.kii.thingif.exception.ThingIFRestException;
 import com.kii.thingif.exception.UnloadableInstanceVersionException;
 import com.kii.thingif.exception.UnregisteredAliasException;
-import com.kii.thingif.exception.UnsupportedActionException;
 import com.kii.thingif.gateway.EndNode;
 import com.kii.thingif.gateway.Gateway;
 import com.kii.thingif.gateway.PendingEndNode;
@@ -893,7 +891,6 @@ public class ThingIFAPI {
      * @return Command instance.
      * @throws ThingIFException Thrown when failed to connect IoT Cloud Server.
      * @throws ThingIFRestException Thrown when server returns error response.
-     * @throws UnsupportedActionException Thrown when the returned response contains unregistered actions.
      */
     @NonNull
     @WorkerThread
@@ -940,7 +937,6 @@ public class ThingIFAPI {
      * paginationKey if there is next page to be obtained.
      * @throws ThingIFException Thrown when failed to connect IoT Cloud Server.
      * @throws ThingIFRestException Thrown when server returns error response.
-     * @throws UnregisteredAliasException Thrown when the returned response contains alias that cannot be handled.
      */
     @NonNull
     public Pair<List<Command>, String> listCommands (
@@ -1185,7 +1181,6 @@ public class ThingIFAPI {
      * @return Trigger instance.
      * @throws ThingIFException Thrown when failed to connect IoT Cloud Server.
      * @throws ThingIFRestException Thrown when server returns error response.
-     * @throws UnregisteredAliasException Thrown when the returned response contains alias that cannot be handled.
      */
     @NonNull
     @WorkerThread
@@ -1565,7 +1560,6 @@ public class ThingIFAPI {
      * in the target.
      * @throws ThingIFException Thrown when failed to connect IoT Cloud Server.
      * @throws ThingIFRestException Thrown when server returns error response.
-     * @throws UnregisteredAliasException Thrown when the returned response contains alias that cannot be handled.
      */
     @NonNull
     @WorkerThread

--- a/thingif/src/test/java/com/kii/thingif/thingifapi/GetCommandTest.java
+++ b/thingif/src/test/java/com/kii/thingif/thingifapi/GetCommandTest.java
@@ -326,5 +326,6 @@ public class GetCommandTest  extends ThingIFAPITestBase {
         String accessToken = "thing-access-token-1234";
         Target target = new StandaloneThing(thingID.getID(), "vendor-thing-id", accessToken);
         ThingIFAPIUtils.setTarget(api, target);
+        api.getCommand("");
     }
 }

--- a/thingif/src/test/java/com/kii/thingif/thingifapi/GetCommandTest.java
+++ b/thingif/src/test/java/com/kii/thingif/thingifapi/GetCommandTest.java
@@ -19,8 +19,6 @@ import com.kii.thingif.command.CommandState;
 import com.kii.thingif.exception.ForbiddenException;
 import com.kii.thingif.exception.NotFoundException;
 import com.kii.thingif.exception.ServiceUnavailableException;
-import com.kii.thingif.exception.UnregisteredAliasException;
-import com.kii.thingif.exception.UnsupportedActionException;
 import com.kii.thingif.states.AirConditionerState;
 import com.kii.thingif.states.HumidityState;
 import com.kii.thingif.thingifapi.utils.ThingIFAPIUtils;
@@ -328,63 +326,5 @@ public class GetCommandTest  extends ThingIFAPITestBase {
         String accessToken = "thing-access-token-1234";
         Target target = new StandaloneThing(thingID.getID(), "vendor-thing-id", accessToken);
         ThingIFAPIUtils.setTarget(api, target);
-        api.getCommand("");
-    }
-
-    @Test()
-    public void getCommandWithUnregisterAliasTest() throws Exception{
-        String commandID = "command-1234";
-        TypedID thingID = new TypedID(TypedID.Types.THING, "th.1234567890");
-        String accessToken = "thing-access-token-1234";
-        Target target = new StandaloneThing(thingID.getID(), "vendor-thing-id", accessToken);
-        String commandTitle = "title";
-        String commandDescription = "description";
-        JSONObject metaData = new JSONObject().put("k", "v");
-        String firedTriggerID = "trigger1";
-        CommandState state = CommandState.SENDING;
-        Long created = System.currentTimeMillis();
-        Long modified = System.currentTimeMillis();
-
-        // prepare the get command response
-        JSONArray actionsInResponse = new JSONArray();
-        actionsInResponse
-                .put(new JSONObject().put(
-                        "NewAlias",
-                        new JSONArray()
-                                .put(new JSONObject().put("newAction", true))));
-
-        this.addMockResponseForGetCommand(
-                200,
-                commandID,
-                api.getOwner().getTypedID(),
-                target.getTypedID(),
-                actionsInResponse,
-                null,
-                state,
-                created,
-                modified,
-                firedTriggerID,
-                commandTitle,
-                commandDescription,
-                metaData);
-        ThingIFAPIUtils.setTarget(api, target);
-        try {
-            api.getCommand(commandID);
-            Assert.fail("UnregisteredAliasException should be thrown");
-        }catch (UnsupportedActionException ex) {
-        }
-
-        // verify the request
-        RecordedRequest request = this.server.takeRequest(1, TimeUnit.SECONDS);
-        Assert.assertEquals(
-                BASE_PATH + "/targets/" + thingID.toString() + "/commands/" + commandID,
-                request.getPath());
-        Assert.assertEquals("GET", request.getMethod());
-
-        Map<String, String> expectedRequestHeaders = new HashMap<>();
-        expectedRequestHeaders.put("X-Kii-AppID", APP_ID);
-        expectedRequestHeaders.put("X-Kii-AppKey", APP_KEY);
-        expectedRequestHeaders.put("Authorization", "Bearer " + api.getOwner().getAccessToken());
-        this.assertRequestHeader(expectedRequestHeaders, request);
     }
 }


### PR DESCRIPTION
In PR: #297 , we changed action when parsing commands.  If command json data from server contains unregistered action, sdk ignore it. 

The failed small test tested when there is unregistered action, throw exception. 
