### PR TITLE
Large tests via Test Lab

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v[0-9]+(\.[0-9]+){0,2}((-.*)?)?$/
+              only: /v[0-9]+(\.[0-9]+){0,2}([-+].+)?/
       - deployment:
           requires:
             - build
@@ -127,7 +127,7 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              only: /^v[0-9]+(\.[0-9]+){0,2}((-.*)?)?$/
+              only: /v[0-9]+(\.[0-9]+){0,2}([-+].+)?/
   # only do large test on ltest* branches.
   large_test:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,6 @@ jobs:
     docker:
       - image: google/cloud-sdk
     steps:
-      - checkout
       - attach_workspace:
           at: large-test-apks
       # refer: https://circleci.com/docs/2.0/google-auth/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,7 +96,7 @@ jobs:
           command: |
             mkdir firebase
             # Note: please set TEST_RESULT_LINK with appropriate link. You can get it from firebase portal under test lab
-            gsutil -m cp -r -U "`gsutil ls gs://${TEST_RESULT_LINK} | tail -1`*" firebase/
+            gsutil -m cp -r -U "`gsutil ls ${TEST_RESULT_LINK} | tail -1`*" firebase/
       - store_artifacts:
           path: firebase/
           destination: /firebase/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,6 @@ jobs:
       - run:
           name: Run instrumented test on Firebase Test Lab
           command: |
-            # make build not faild caused by failure of tests, since we would like to collect test result from gcloud
             gcloud firebase test android run \
               --type instrumentation \
               --app large-test-apks/thingiftest-debug.apk \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -132,12 +132,12 @@ workflows:
   large_test:
     jobs:
       - build:
-          branches:
-            only:
-              /ltest.*/
+          filters:
+            branches:
+              only: /ltest.*/
       - large_test:
           requires:
             - build
-          branches:
-            only:
-              /ltest.*/
+          filters:
+            branches:
+              only: /ltest.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,8 +96,8 @@ jobs:
           name: Download instrumented test results from Firebase Test Lab
           command: |
             mkdir firebase
-            # Note: test-lab-6392988w852y6-k75m1yx2tf60u need to be changed if google account for test is changed.
-            gsutil -m cp -r -U "`gsutil ls gs://test-lab-6392988w852y6-k75m1yx2tf60u | tail -1`*" firebase/
+            # Note: please set TEST_RESULT_LINK with appropriate link. You can get it from firebase portal under test lab
+            gsutil -m cp -r -U "`gsutil ls gs://${TEST_RESULT_LINK} | tail -1`*" firebase/
       - store_artifacts:
           path: firebase/
           destination: /firebase/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,11 +36,12 @@ jobs:
       - run:
           name: build large test module
           command: |
-            mkdir large-test-apks
+            mkdir large-test-apks # folder to save generated apks for large tests
             ./gradlew :thingiftest:assembleDebug
             ./gradlew :thingiftest:assembleAndroidTest
             cp thingiftest/build/outputs/apk/thingiftest-debug.apk large-test-apks/
             cp thingiftest/build/outputs/apk/thingiftest-debug-androidTest.apk large-test-apks/
+      # stored the apks in workspace for large_test job
       - persist_to_workspace:
           root: large-test-apks
           paths:
@@ -65,9 +66,11 @@ jobs:
       - checkout
       - attach_workspace:
           at: large-test-apks
+      # refer: https://circleci.com/docs/2.0/google-auth/
       - run:
           name: Store Service Account
           command: echo $GCLOUD_SERVICE_KEY > ${HOME}/gcloud-service-key.json
+      # refer: https://circleci.com/docs/2.0/google-auth/
       - run: |
           gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
           gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
@@ -93,6 +96,7 @@ jobs:
           name: Download instrumented test results from Firebase Test Lab
           command: |
             mkdir firebase
+            # Note: test-lab-6392988w852y6-k75m1yx2tf60u need to be changed if google account for test is changed.
             gsutil -m cp -r -U "`gsutil ls gs://test-lab-6392988w852y6-k75m1yx2tf60u | tail -1`*" firebase/
       - store_artifacts:
           path: firebase/
@@ -124,6 +128,7 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v[0-9]+(\.[0-9]+){0,2}((-.*)?)?$/
+  # only do large test on ltest* branches.
   large_test:
     jobs:
       - build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,19 @@ jobs:
       - run: ./gradlew :thingif:test
       - store_test_results:
           path: thingif/build/test-results
+      - run:
+          name: build large test module
+          command: |
+            mkdir large-test-apks
+            ./gradlew :thingiftest:assembleDebug
+            ./gradlew :thingiftest:assembleAndroidTest
+            cp thingiftest/build/outputs/apk/thingiftest-debug.apk large-test-apks/
+            cp thingiftest/build/outputs/apk/thingiftest-debug-androidTest.apk large-test-apks/
+      - persist_to_workspace:
+          root: large-test-apks
+          paths:
+            - thingiftest-debug.apk
+            - thingiftest-debug-androidTest.apk
   deployment:
     docker:
       - image: circleci/android:api-25-alpha
@@ -45,6 +58,48 @@ jobs:
           key: api-doc-{{ .Revision }}
       - run: bash circleci_scripts/release_doc.sh
       - run: ./gradlew bintrayUpload
+  large_test:
+    docker:
+      - image: google/cloud-sdk
+    steps:
+      - checkout
+      - attach_workspace:
+          at: large-test-apks
+      - run:
+          name: Store Service Account
+          command: echo $GCLOUD_SERVICE_KEY > ${HOME}/gcloud-service-key.json
+      - run: |
+          gcloud auth activate-service-account --key-file=${HOME}/gcloud-service-key.json
+          gcloud --quiet config set project ${GOOGLE_PROJECT_ID}
+          gcloud --quiet config set compute/zone ${GOOGLE_COMPUTE_ZONE}
+      - run:
+          name: Run instrumented test on Firebase Test Lab
+          command: |
+            # make build not faild caused by failure of tests, since we would like to collect test result from gcloud
+            gcloud firebase test android run \
+              --type instrumentation \
+              --app large-test-apks/thingiftest-debug.apk \
+              --test large-test-apks/thingiftest-debug-androidTest.apk \
+              --device model=Pixel2,version=28,locale=en_US,orientation=portrait \
+              --device model=NexusLowRes,version=27,locale=en_US,orientation=portrait \
+              --device model=Nexus10,version=19,locale=en_US,orientation=portrait \
+              --environment-variables coverage=true,coverageFile=/sdcard/tmp/code-coverage/connected/coverage.ec \
+              --directories-to-pull=/sdcard/tmp \
+              --timeout 20m
+      - run:
+          name: Create directory to store test results
+          command: mkdir firebase
+      - run:
+          when: always
+          name: Download instrumented test results from Firebase Test Lab
+          command: |
+            mkdir firebase
+            gsutil -m cp -r -U "`gsutil ls gs://test-lab-6392988w852y6-k75m1yx2tf60u | tail -1`*" firebase/
+      - store_artifacts:
+          path: firebase/
+          destination: /firebase/
+      - store_test_results:
+          path: firebase/
 
 workflows:
   version: 2
@@ -70,3 +125,15 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v[0-9]+(\.[0-9]+){0,2}((-.*)?)?$/
+  large_test:
+    jobs:
+      - build:
+          branches:
+            only:
+              /ltest.*/
+      - large_test:
+          requires:
+            - build
+          branches:
+            only:
+              /ltest.*/


### PR DESCRIPTION
### Changes
- generate apks of thingiftest module (debug archive and androidTest archive) in build job, which are used in large test
- add large test job, utilizing google cloud console
  - uploading apks to firebase to do instrumented test
  - collecting test result from google cloud, saved it in circle ci
- test on 3 virtual device: latest android (28), latest stable android (27), available earliest android (19)

### Reference:
https://medium.com/@ayltai/all-you-need-to-know-about-circleci-2-0-with-firebase-test-lab-2a66785ff3c2
https://circleci.com/docs/2.0/google-auth/

### Out of scope: 
- fix failed large test. 
- upgrade compileSDKVersion